### PR TITLE
Adding a zombie period when disconnecting

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -98,6 +98,14 @@ EnterRoomMessageWrapper: "   <ansi fg=\"enters-message\"> >>> </ansi>%s"
 # - ExitRoomMessageWrapper -
 #   Decorate exit text with this. Put a %s where the message should be.
 ExitRoomMessageWrapper: "   <ansi fg=\"leaves-message\"> >>> </ansi>%s"
+# - ZombieSeconds -
+#   How many seconds a character stays active/in game after a network connection
+#   is lost. Set to 0 to instantly log out characters (exploitable).
+ZombieSeconds: 30
+# - LogoutRounds - 
+#   How many rounds of meditation a player must complete before they are
+#   logged out. If interrupted, they must start over.
+LogoutRounds: 3
 ################################################################################
 #
 #   MEMORY/CPU OPTIMIZATIONS

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -56,6 +56,9 @@ type config struct {
 	EnterRoomMessageWrapper    ConfigString `yaml:"EnterRoomMessageWrapper"`
 	ExitRoomMessageWrapper     ConfigString `yaml:"ExitRoomMessageWrapper"`
 
+	ZombieSeconds ConfigInt `yaml:"ZombieSeconds"` // How many seconds a player will be a zombie allowing them to reconnect.
+	LogoutRounds  ConfigInt `yaml:"LogoutRounds"`  // How many rounds of uninterrupted meditation must be completed to log out.
+
 	// Protected values
 	turnsPerRound   int     // calculated and cached when data is validated.
 	turnsPerSave    int     // calculated and cached when data is validated.
@@ -338,6 +341,14 @@ func (c *config) Validate() {
 	}
 	if strings.LastIndex(string(c.ExitRoomMessageWrapper), `%s`) < 0 {
 		c.ExitRoomMessageWrapper += `%s` // default
+	}
+
+	// Zombie configs
+	if c.ZombieSeconds < 0 {
+		c.ZombieSeconds = 0 // default
+	}
+	if c.LogoutRounds < 0 {
+		c.LogoutRounds = 3 // default
 	}
 
 	if c.RoundsPerAutoSave < 1 {

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -57,6 +57,22 @@ func (c *ConnectionTracker) Cleanup() {
 	})
 }
 
+func (c *ConnectionTracker) Kick(id ConnectionId) (err error) {
+
+	// Try to retrieve the value
+	if cd, ok := c.netConnections.Load(id); ok {
+		// close the connection, no longer useful.
+		cd.(*ConnectionDetails).Close()
+		// keep track of the number of disconnects
+		atomic.AddUint64(&c.disconnectCounter, 1)
+		// remove the connection from the map
+		slog.Info("connection kicked", "connectionId", id, "remoteAddr", cd.(*ConnectionDetails).RemoteAddr().String())
+		return nil
+	}
+
+	return errors.New("connection not found")
+}
+
 func (c *ConnectionTracker) Remove(id ConnectionId) (err error) {
 
 	//if err := users.LogOutUserByConnectionId(id); err != nil {

--- a/inputhandlers/login.go
+++ b/inputhandlers/login.go
@@ -112,13 +112,17 @@ func LoginInputHandler(clientInput *connection.ClientInput, connectionPool *conn
 			} else {
 				// Password matched, assign the loaded data
 				state.UserObject = tmpUser
-				if err := users.LoginUser(tmpUser, clientInput.ConnectionId); err != nil {
 
-					connectionPool.SendTo([]byte("That user is already logged in. Bye!"), clientInput.ConnectionId)
+				msg, err := users.LoginUser(tmpUser, clientInput.ConnectionId)
+
+				if len(msg) > 0 {
+					connectionPool.SendTo([]byte(msg), clientInput.ConnectionId)
 					connectionPool.SendTo(term.CRLF, clientInput.ConnectionId) // Newline
+				}
+
+				if err != nil {
 					connectionPool.Remove(clientInput.ConnectionId)
 					return false
-
 				}
 
 				return true

--- a/inputhandlers/systemcommands.go
+++ b/inputhandlers/systemcommands.go
@@ -114,7 +114,7 @@ func trySystemCommand(cmd string, connectionPool *connection.ConnectionTracker, 
 		tplTxt, _ := templates.Process("goodbye", nil, templates.AnsiTagsPreParse)
 		connectionPool.SendTo([]byte(tplTxt), connectionId)
 
-		connectionPool.Remove(connectionId)
+		connectionPool.Kick(connectionId)
 		return true
 	}
 

--- a/users/userrecord.go
+++ b/users/userrecord.go
@@ -51,6 +51,7 @@ type UserRecord struct {
 	tempDataStore  map[string]any
 	activePrompt   *prompt.Prompt
 	progress       *progressbar.ProgressBar
+	isZombie       bool // are they a zombie currently?
 }
 
 func NewUserRecord(userId int, connectionId uint64) *UserRecord {

--- a/users/users.go
+++ b/users/users.go
@@ -30,11 +30,13 @@ var (
 
 type ActiveUsers struct {
 	sync.RWMutex
-	Users           map[int]*UserRecord             // userId to UserRecord
-	Usernames       map[string]int                  // username to userId
-	Connections     map[connection.ConnectionId]int // connectionId to userId
-	UserConnections map[int]connection.ConnectionId // userId to connectionId
+	Users             map[int]*UserRecord                // userId to UserRecord
+	Usernames         map[string]int                     // username to userId
+	Connections       map[connection.ConnectionId]int    // connectionId to userId
+	UserConnections   map[int]connection.ConnectionId    // userId to connectionId
+	ZombieConnections map[connection.ConnectionId]uint64 // connectionId to turn they became a zombie
 }
+
 type Online struct {
 	UserId         string
 	Username       string
@@ -47,11 +49,43 @@ type Online struct {
 
 func NewUserManager() *ActiveUsers {
 	return &ActiveUsers{
-		Users:           make(map[int]*UserRecord),
-		Usernames:       make(map[string]int),
-		Connections:     make(map[connection.ConnectionId]int),
-		UserConnections: make(map[int]connection.ConnectionId),
+		Users:             make(map[int]*UserRecord),
+		Usernames:         make(map[string]int),
+		Connections:       make(map[connection.ConnectionId]int),
+		UserConnections:   make(map[int]connection.ConnectionId),
+		ZombieConnections: make(map[connection.ConnectionId]uint64),
 	}
+}
+
+func RemoveZombieUser(userId int) {
+	userManager.Lock()
+	defer userManager.Unlock()
+
+	connId := userManager.UserConnections[userId]
+	delete(userManager.ZombieConnections, connId)
+}
+
+func RemoveZombieConnection(connectionId connection.ConnectionId) {
+	userManager.Lock()
+	defer userManager.Unlock()
+
+	delete(userManager.ZombieConnections, connectionId)
+}
+
+func GetExpiredZombies(expirationTurn uint64) []int {
+	userManager.Lock()
+	defer userManager.Unlock()
+
+	expiredUsers := make([]int, 0)
+
+	for connectionId, zombieTurn := range userManager.ZombieConnections {
+		if zombieTurn < expirationTurn {
+			slog.Info("TEST", "expiration", expirationTurn, "zombieTurn", zombieTurn)
+			expiredUsers = append(expiredUsers, userManager.Connections[connectionId])
+		}
+	}
+
+	return expiredUsers
 }
 
 func GetConnectionIds(userIds []int) []connection.ConnectionId {
@@ -137,29 +171,77 @@ func GetByConnectionId(connectionId connection.ConnectionId) *UserRecord {
 }
 
 // First time creating a user.
-func LoginUser(u *UserRecord, connectionId connection.ConnectionId) error {
+func LoginUser(u *UserRecord, connectionId connection.ConnectionId) (string, error) {
 
-	u.connectionId = connectionId
-
-	slog.Info("Logging in user", "username", u.Username, "connectionId", u.connectionId)
+	slog.Info("Logging in user", "username", u.Username, "connectionId", connectionId)
 
 	userManager.Lock()
 	defer userManager.Unlock()
 
-	if _, ok := userManager.Usernames[u.Username]; ok {
-		return errors.New("user is already logged in")
+	if userId, ok := userManager.Usernames[u.Username]; ok {
+
+		if otherConnId, ok := userManager.UserConnections[userId]; ok {
+
+			if _, ok := userManager.ZombieConnections[otherConnId]; ok {
+
+				// The user is a zombie.
+				delete(userManager.ZombieConnections, otherConnId)
+
+				u.connectionId = connectionId
+
+				userManager.Users[u.UserId] = u
+				userManager.Usernames[u.Username] = u.UserId
+				userManager.Connections[u.connectionId] = u.UserId
+				userManager.UserConnections[u.UserId] = u.connectionId
+
+				return "Reconnecting...", nil
+			}
+
+		}
+
+		return "That user is already logged in.", errors.New("user is already logged in")
 	}
 
 	if len(u.AdminCommands) > 0 {
 		u.Permission = PermissionMod
 	}
 
+	u.connectionId = connectionId
+
 	userManager.Users[u.UserId] = u
 	userManager.Usernames[u.Username] = u.UserId
 	userManager.Connections[u.connectionId] = u.UserId
 	userManager.UserConnections[u.UserId] = u.connectionId
 
-	return nil
+	return "", nil
+}
+
+func SetZombieConnection(connId connection.ConnectionId) {
+
+	userManager.Lock()
+	defer userManager.Unlock()
+
+	if _, ok := userManager.ZombieConnections[connId]; ok {
+		return
+	}
+
+	userManager.ZombieConnections[connId] = util.GetTurnCount()
+}
+
+func SetZombieUser(userId int) {
+
+	userManager.Lock()
+	defer userManager.Unlock()
+
+	if u, ok := userManager.Users[userId]; ok {
+
+		if _, ok := userManager.ZombieConnections[u.connectionId]; ok {
+			return
+		}
+
+		userManager.ZombieConnections[u.connectionId] = util.GetTurnCount()
+	}
+
 }
 
 func SaveAllUsers() {


### PR DESCRIPTION
# Motivation

To avoid players being able to disconnect as an exploit to avoid dying etc., we want a zombie period where their character remains in play even though their network connection is gone.

Later this may be enhanced to allow auto-behavior for the player.

# Changes

* Added new config values related to zombification period

* Players can reconnect to their zombie self 

* `/quit` command now just disconnects the network and basically zombifies them.

