### PR TITLE
Rewrite command function signatures

### DIFF
--- a/mobcommands/aid.go
+++ b/mobcommands/aid.go
@@ -1,8 +1,6 @@
 package mobcommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/buffs"
 	"github.com/volte6/mud/characters"
 	"github.com/volte6/mud/mobs"
@@ -13,19 +11,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Aid(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Aid(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	raceInfo := races.GetRace(mob.Character.RaceId)
 	if !raceInfo.KnowsFirstAid {
@@ -66,7 +52,7 @@ func Aid(rest string, mobId int) (bool, error) {
 			}
 
 			continueCasting := true
-			if allowToContinue, err := scripting.TrySpellScriptEvent(`onCast`, 0, mobId, spellAggro); err == nil {
+			if allowToContinue, err := scripting.TrySpellScriptEvent(`onCast`, 0, mob.InstanceId, spellAggro); err == nil {
 				continueCasting = allowToContinue
 			}
 

--- a/mobcommands/alchemy.go
+++ b/mobcommands/alchemy.go
@@ -10,15 +10,8 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Alchemy(rest string, mobId int) (bool, error) {
+func Alchemy(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	if room == nil {
 		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
@@ -29,7 +22,7 @@ func Alchemy(rest string, mobId int) (bool, error) {
 		// select a random item
 		if len(mob.Character.Items) > 0 {
 			matchItem := mob.Character.Items[util.Rand(len(mob.Character.Items))]
-			Alchemy(matchItem.Name(), mobId)
+			Alchemy(matchItem.Name(), mob, room)
 
 		}
 		return true, nil
@@ -43,7 +36,7 @@ func Alchemy(rest string, mobId int) (bool, error) {
 		}
 
 		for _, item := range iCopies {
-			Alchemy(item.Name(), mobId)
+			Alchemy(item.Name(), mob, room)
 		}
 
 		return true, nil

--- a/mobcommands/attack.go
+++ b/mobcommands/attack.go
@@ -12,19 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Attack(rest string, mobId int) (bool, error) {
-
-	// Load mob details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Attack(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
@@ -39,7 +27,7 @@ func Attack(rest string, mobId int) (bool, error) {
 		// If no argument supplied, attack whoever is attacking the player currently.
 		for _, mId := range room.GetMobs(rooms.FindFightingMob) {
 			m := mobs.GetInstance(mId)
-			if m.Character.Aggro != nil && m.Character.Aggro.MobInstanceId == mobId {
+			if m.Character.Aggro != nil && m.Character.Aggro.MobInstanceId == mob.InstanceId {
 				attackMobInstanceId = m.InstanceId
 				break
 			}
@@ -48,7 +36,7 @@ func Attack(rest string, mobId int) (bool, error) {
 		if attackMobInstanceId == 0 {
 			for _, uId := range room.GetPlayers(rooms.FindFightingMob) {
 				u := users.GetByUserId(uId)
-				if u.Character.Aggro != nil && u.Character.Aggro.MobInstanceId == mobId {
+				if u.Character.Aggro != nil && u.Character.Aggro.MobInstanceId == mob.InstanceId {
 					attackPlayerId = u.UserId
 					break
 				}
@@ -58,7 +46,7 @@ func Attack(rest string, mobId int) (bool, error) {
 		attackPlayerId, attackMobInstanceId = room.FindByName(rest)
 	}
 
-	if attackMobInstanceId == mobId { // Can't attack self!
+	if attackMobInstanceId == mob.InstanceId { // Can't attack self!
 		attackMobInstanceId = 0
 	}
 

--- a/mobcommands/backstab.go
+++ b/mobcommands/backstab.go
@@ -1,8 +1,6 @@
 package mobcommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/buffs"
 	"github.com/volte6/mud/characters"
 	"github.com/volte6/mud/mobs"
@@ -10,24 +8,12 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Backstab(rest string, mobId int) (bool, error) {
-
-	// Load mob details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func Backstab(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Must be sneaking
 	isSneaking := mob.Character.HasBuffFlag(buffs.Hidden)
 	if !isSneaking {
 		return true, nil
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
 
 	attackPlayerId := 0
@@ -42,7 +28,7 @@ func Backstab(rest string, mobId int) (bool, error) {
 			// If no argument supplied, attack whoever is attacking the player currently.
 			for _, mId := range room.GetMobs(rooms.FindFightingMob) {
 				m := mobs.GetInstance(mId)
-				if m.Character.Aggro != nil && m.Character.Aggro.MobInstanceId == mobId {
+				if m.Character.Aggro != nil && m.Character.Aggro.MobInstanceId == mob.InstanceId {
 					attackMobInstanceId = m.InstanceId
 					break
 				}
@@ -51,7 +37,7 @@ func Backstab(rest string, mobId int) (bool, error) {
 			if attackMobInstanceId == 0 {
 				for _, uId := range room.GetPlayers(rooms.FindFightingMob) {
 					u := users.GetByUserId(uId)
-					if u.Character.Aggro != nil && u.Character.Aggro.MobInstanceId == mobId {
+					if u.Character.Aggro != nil && u.Character.Aggro.MobInstanceId == mob.InstanceId {
 						attackPlayerId = u.UserId
 						break
 					}
@@ -63,7 +49,7 @@ func Backstab(rest string, mobId int) (bool, error) {
 		attackPlayerId, attackMobInstanceId = room.FindByName(rest)
 	}
 
-	if attackMobInstanceId == mobId {
+	if attackMobInstanceId == mob.InstanceId {
 		attackMobInstanceId = 0
 	}
 

--- a/mobcommands/befriend.go
+++ b/mobcommands/befriend.go
@@ -9,19 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Befriend(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Befriend(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	if rest == `revert` {
 

--- a/mobcommands/break.go
+++ b/mobcommands/break.go
@@ -7,15 +7,8 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Break(rest string, mobId int) (bool, error) {
+func Break(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	if room == nil {
 		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}

--- a/mobcommands/callforhelp.go
+++ b/mobcommands/callforhelp.go
@@ -11,22 +11,10 @@ import (
 // Format should be:
 // callforhelp blows his horn
 // "blows his horn" will be emoted to the room
-func CallForHelp(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func CallForHelp(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	if mob.Character.Aggro == nil || mob.Character.Aggro.UserId == 0 {
-		return false, fmt.Errorf(`mob %d has no aggro`, mobId)
+		return false, fmt.Errorf(`mob %d has no aggro`, mob.InstanceId)
 	}
 
 	calledForHelp := false

--- a/mobcommands/converse.go
+++ b/mobcommands/converse.go
@@ -10,19 +10,7 @@ import (
 	"github.com/volte6/mud/scripting"
 )
 
-func Converse(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Converse(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Don't bother if no players are present
 	if room.PlayerCt() < 1 {
@@ -32,9 +20,9 @@ func Converse(rest string, mobId int) (bool, error) {
 	isSneaking := mob.Character.HasBuffFlag(buffs.Hidden)
 
 	if isSneaking {
-		room.SendText(fmt.Sprintf(`someone says, "<ansi fg="yellow">%s</ansi>"`, rest), mobId)
+		room.SendText(fmt.Sprintf(`someone says, "<ansi fg="yellow">%s</ansi>"`, rest))
 	} else {
-		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> says, "<ansi fg="yellow">%s</ansi>"`, mob.Character.Name, rest), mobId)
+		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> says, "<ansi fg="yellow">%s</ansi>"`, mob.Character.Name, rest))
 	}
 
 	roomMobs := room.GetMobs(rooms.FindIdle)
@@ -51,12 +39,12 @@ func Converse(rest string, mobId int) (bool, error) {
 			continue
 		}
 
-		mob := mobs.GetInstance(roomMobInstId)
-		if mob == nil {
+		targetMob := mobs.GetInstance(roomMobInstId)
+		if targetMob == nil {
 			continue
 		}
 
-		if handled, err := scripting.TryMobConverse(rest, roomMobInstId, mobId); err == nil {
+		if handled, err := scripting.TryMobConverse(rest, targetMob.InstanceId, mob.InstanceId); err == nil {
 			if handled {
 				return true, nil
 			}

--- a/mobcommands/despawn.go
+++ b/mobcommands/despawn.go
@@ -8,15 +8,8 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Despawn(rest string, mobId int) (bool, error) {
+func Despawn(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	if room == nil {
 		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}

--- a/mobcommands/drink.go
+++ b/mobcommands/drink.go
@@ -10,19 +10,7 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Drink(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Drink(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	if matchItem, found := mob.Character.FindInBackpack(rest); found {
@@ -37,7 +25,7 @@ func Drink(rest string, mobId int) (bool, error) {
 
 		mob.Character.UseItem(matchItem)
 
-		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> drinks <ansi fg="itemname">%s</ansi>.`, mob.Character.Name, matchItem.DisplayName()), mobId)
+		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> drinks <ansi fg="itemname">%s</ansi>.`, mob.Character.Name, matchItem.DisplayName()))
 
 		for _, buffId := range itemSpec.BuffIds {
 

--- a/mobcommands/drop.go
+++ b/mobcommands/drop.go
@@ -11,19 +11,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Drop(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Drop(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
@@ -32,7 +20,7 @@ func Drop(rest string, mobId int) (bool, error) {
 		iCopies := []items.Item{}
 
 		if mob.Character.Gold > 0 {
-			Drop(fmt.Sprintf("%d gold", mob.Character.Gold), mobId)
+			Drop(fmt.Sprintf("%d gold", mob.Character.Gold), mob, room)
 		}
 
 		for _, item := range mob.Character.Items {
@@ -40,7 +28,7 @@ func Drop(rest string, mobId int) (bool, error) {
 		}
 
 		for _, item := range iCopies {
-			Drop(item.Name(), mobId)
+			Drop(item.Name(), mob, room)
 		}
 
 		return true, nil

--- a/mobcommands/eat.go
+++ b/mobcommands/eat.go
@@ -10,19 +10,7 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Eat(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Eat(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	if matchItem, found := mob.Character.FindInBackpack(rest); found {
 
@@ -36,7 +24,7 @@ func Eat(rest string, mobId int) (bool, error) {
 
 		mob.Character.UseItem(matchItem)
 
-		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> eats some <ansi fg="itemname">%s</ansi>.`, mob.Character.Name, matchItem.DisplayName()), mobId)
+		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> eats some <ansi fg="itemname">%s</ansi>.`, mob.Character.Name, matchItem.DisplayName()))
 
 		for _, buffId := range itemSpec.BuffIds {
 

--- a/mobcommands/emote.go
+++ b/mobcommands/emote.go
@@ -92,19 +92,7 @@ var (
 	}
 )
 
-func Emote(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Emote(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Don't bother if no players are present
 	if room.PlayerCt() < 1 {

--- a/mobcommands/equip.go
+++ b/mobcommands/equip.go
@@ -10,15 +10,8 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Equip(rest string, mobId int) (bool, error) {
+func Equip(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	if room == nil {
 		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
@@ -30,7 +23,7 @@ func Equip(rest string, mobId int) (bool, error) {
 		for _, item := range itemCopies {
 			iSpec := item.GetSpec()
 			if iSpec.Subtype == items.Wearable || iSpec.Type == items.Weapon {
-				Equip(item.Name(), mobId)
+				Equip(item.Name(), mob, room)
 			}
 		}
 		return true, nil

--- a/mobcommands/gearup.go
+++ b/mobcommands/gearup.go
@@ -8,19 +8,7 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Gearup(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Gearup(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	if rest != `` {
 		// Check whether the user has an item in their inventory that matches

--- a/mobcommands/get.go
+++ b/mobcommands/get.go
@@ -11,19 +11,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Get(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Get(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
@@ -33,7 +21,7 @@ func Get(rest string, mobId int) (bool, error) {
 
 	if args[0] == "all" {
 		if room.Gold > 0 {
-			Get("gold", mobId)
+			Get("gold", mob, room)
 		}
 
 		if len(room.Items) > 0 {
@@ -43,7 +31,7 @@ func Get(rest string, mobId int) (bool, error) {
 			}
 
 			for _, item := range iCopies {
-				Get(item.Name(), mobId)
+				Get(item.Name(), mob, room)
 			}
 		}
 

--- a/mobcommands/give.go
+++ b/mobcommands/give.go
@@ -14,19 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Give(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Give(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	rest = util.StripPrepositions(rest)
 

--- a/mobcommands/givequest.go
+++ b/mobcommands/givequest.go
@@ -1,7 +1,6 @@
 package mobcommands
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/volte6/mud/events"
@@ -14,19 +13,7 @@ import (
 // or
 // givequest 1-start Say has anyone seen my locket?
 // The second message will only be executed if the quest is successfully given.
-func GiveQuest(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func GiveQuest(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Don't bother if no players are present
 	if room.PlayerCt() < 1 {

--- a/mobcommands/go.go
+++ b/mobcommands/go.go
@@ -10,23 +10,11 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Go(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func Go(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// If has a buff that prevents combat, skip the player
 	if mob.Character.HasBuffFlag(buffs.NoMovement) {
 		return true, nil
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
 
 	exitName := ``
@@ -130,8 +118,8 @@ func Go(rest string, mobId int) (bool, error) {
 			}
 		}
 
-		room.RemoveMob(mobId)
-		destRoom.AddMob(mobId)
+		room.RemoveMob(mob.InstanceId)
+		destRoom.AddMob(mob.InstanceId)
 
 		c := configs.GetConfig()
 

--- a/mobcommands/look.go
+++ b/mobcommands/look.go
@@ -11,24 +11,12 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Look(rest string, mobId int) (bool, error) {
+func Look(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	secretLook := false
 	if strings.HasPrefix(rest, "secretly") {
 		secretLook = true
 		rest = strings.TrimSpace(strings.TrimPrefix(rest, "secretly"))
-	}
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
 
 	isSneaking := mob.Character.HasBuffFlag(buffs.Hidden)
@@ -51,12 +39,12 @@ func Look(rest string, mobId int) (bool, error) {
 			}
 
 			if !isSneaking {
-				room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> peers toward the %s.`, mob.Character.Name, exitName), mobId)
+				room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> peers toward the %s.`, mob.Character.Name, exitName))
 			}
 
 			if lookRoomId > 0 {
 
-				lookRoom(mobId, lookRoomId, secretLook || isSneaking)
+				lookRoom(mob, lookRoomId, secretLook || isSneaking)
 
 				return true, nil
 			}
@@ -141,15 +129,14 @@ func Look(rest string, mobId int) (bool, error) {
 			// Make it a "secret looks" now because we don't want another look message sent out by the lookRoom() func
 			secretLook = true
 		}
-		lookRoom(mobId, room.RoomId, secretLook || isSneaking)
+		lookRoom(mob, room.RoomId, secretLook || isSneaking)
 	}
 
 	return true, nil
 }
 
-func lookRoom(mobId int, roomId int, secretLook bool) {
+func lookRoom(mob *mobs.Mob, roomId int, secretLook bool) {
 
-	mob := mobs.GetInstance(mobId)
 	room := rooms.LoadRoom(roomId)
 
 	if mob == nil || room == nil {

--- a/mobcommands/lookforaid.go
+++ b/mobcommands/lookforaid.go
@@ -8,20 +8,13 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func LookForAid(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func LookForAid(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	isCharmed := mob.Character.IsCharmed()
 	if !isCharmed {
 		return true, nil
 	}
 
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	for _, playerId := range room.GetPlayers(rooms.FindDowned) {
 
 		user := users.GetByUserId(playerId)

--- a/mobcommands/lookfortrouble.go
+++ b/mobcommands/lookfortrouble.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func LookForTrouble(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func LookForTrouble(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Already aggroed, skip.
 	if mob.Character.Aggro != nil {
@@ -28,7 +22,6 @@ func LookForTrouble(rest string, mobId int) (bool, error) {
 	// Make a list of all players this gorup is hostile to in this room.
 	isCharmed := mob.Character.IsCharmed()
 
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	allPotentialTargets := []int{}
 	nonDownedUserTargets := []int{}
 	possibleMobTargets := []int{}
@@ -107,7 +100,7 @@ func LookForTrouble(rest string, mobId int) (bool, error) {
 
 		// Still nothing, look for trouble in mobs they hate
 		for _, considerMobInstanceId := range room.GetMobs() {
-			if mobId == considerMobInstanceId {
+			if mob.InstanceId == considerMobInstanceId {
 				continue
 			}
 

--- a/mobcommands/portal.go
+++ b/mobcommands/portal.go
@@ -13,25 +13,13 @@ import (
 
 // Mob portaling is different than player portaling.
 // Mob portals are open for shorter periods, and go to specific locations.
-func Portal(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func Portal(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// This is a hack because using "portal" to enter an existing portal is very common
 	if rest == `` {
-		if handled, err := Go(`portal`, mobId); handled {
+		if handled, err := Go(`portal`, mob, room); handled {
 			return handled, err
 		}
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
 
 	var err error

--- a/mobcommands/remove.go
+++ b/mobcommands/remove.go
@@ -8,22 +8,15 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Remove(rest string, mobId int) (bool, error) {
+func Remove(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	if room == nil {
 		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
 
 	if rest == "all" {
 		for _, item := range mob.Character.Equipment.GetAllItems() {
-			Remove(item.Name(), mobId)
+			Remove(item.Name(), mob, room)
 		}
 		return true, nil
 	}

--- a/mobcommands/say.go
+++ b/mobcommands/say.go
@@ -8,19 +8,7 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Say(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Say(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Don't bother if no players are present
 	if room.PlayerCt() < 1 {
@@ -31,7 +19,7 @@ func Say(rest string, mobId int) (bool, error) {
 	isSneaking := mob.Character.HasBuffFlag(buffs.Hidden)
 
 	if isSneaking {
-		room.SendText(fmt.Sprintf(`someone says, "<ansi fg="saytext">%s</ansi>"`, rest), mobId)
+		room.SendText(fmt.Sprintf(`someone says, "<ansi fg="saytext">%s</ansi>"`, rest))
 	} else {
 		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> says, "<ansi fg="saytext">%s</ansi>"`, mob.Character.Name, rest))
 	}

--- a/mobcommands/shoot.go
+++ b/mobcommands/shoot.go
@@ -13,19 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Shoot(rest string, mobId int) (bool, error) {
-
-	// Load mob details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Shoot(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	if mob.Character.Equipment.Weapon.GetSpec().Subtype != items.Shooting {
 		return true, nil
@@ -84,7 +72,7 @@ func Shoot(rest string, mobId int) (bool, error) {
 
 		if m != nil {
 
-			if m.Character.IsCharmed(mobId) {
+			if m.Character.IsCharmed(mob.InstanceId) {
 				return true, nil
 			}
 

--- a/mobcommands/shout.go
+++ b/mobcommands/shout.go
@@ -9,19 +9,7 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Shout(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Shout(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Don't bother if no players are present
 	if room.PlayerCt() < 1 {
@@ -33,9 +21,9 @@ func Shout(rest string, mobId int) (bool, error) {
 	rest = strings.ToUpper(rest)
 
 	if isSneaking {
-		room.SendText(fmt.Sprintf(`someone shouts, "<ansi fg="yellow">%s</ansi>"`, rest), mobId)
+		room.SendText(fmt.Sprintf(`someone shouts, "<ansi fg="yellow">%s</ansi>"`, rest), mob.InstanceId)
 	} else {
-		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> shouts, "<ansi fg="yellow">%s</ansi>"`, mob.Character.Name, rest), mobId)
+		room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> shouts, "<ansi fg="yellow">%s</ansi>"`, mob.Character.Name, rest), mob.InstanceId)
 	}
 
 	for _, roomInfo := range room.Exits {

--- a/mobcommands/show.go
+++ b/mobcommands/show.go
@@ -12,19 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Show(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
-	}
+func Show(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	rest = util.StripPrepositions(rest)
 

--- a/mobcommands/sneak.go
+++ b/mobcommands/sneak.go
@@ -1,20 +1,13 @@
 package mobcommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/buffs"
 	"github.com/volte6/mud/events"
 	"github.com/volte6/mud/mobs"
+	"github.com/volte6/mud/rooms"
 )
 
-func Sneak(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func Sneak(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Must be sneaking
 	isSneaking := mob.Character.HasBuffFlag(buffs.Hidden)
@@ -24,7 +17,7 @@ func Sneak(rest string, mobId int) (bool, error) {
 
 	events.AddToQueue(events.Buff{
 		UserId:        0,
-		MobInstanceId: mobId,
+		MobInstanceId: mob.InstanceId,
 		BuffId:        9, // Buff 9 is sneak
 	})
 

--- a/mobcommands/suicide.go
+++ b/mobcommands/suicide.go
@@ -16,15 +16,8 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Suicide(rest string, mobId int) (bool, error) {
+func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	if room == nil {
 		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}

--- a/mobcommands/throw.go
+++ b/mobcommands/throw.go
@@ -11,15 +11,8 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Throw(rest string, mobId int) (bool, error) {
+func Throw(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
-	// Load mob details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. mob not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
 	if room == nil {
 		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}

--- a/mobcommands/trash.go
+++ b/mobcommands/trash.go
@@ -1,18 +1,11 @@
 package mobcommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/mobs"
+	"github.com/volte6/mud/rooms"
 )
 
-func Trash(rest string, mobId int) (bool, error) {
-
-	// Load mob details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func Trash(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := mob.Character.FindInBackpack(rest)

--- a/mobcommands/uncurse.go
+++ b/mobcommands/uncurse.go
@@ -8,15 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Uncurse(rest string, mobId int) (bool, error) {
-
-	// Load mob details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
-
-	room := rooms.LoadRoom(mob.Character.RoomId)
+func Uncurse(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	for _, pid := range room.GetPlayers() {
 

--- a/mobcommands/wander.go
+++ b/mobcommands/wander.go
@@ -8,22 +8,10 @@ import (
 	"github.com/volte6/mud/rooms"
 )
 
-func Wander(rest string, mobId int) (bool, error) {
-
-	// Load user details
-	mob := mobs.GetInstance(mobId)
-	if mob == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("mob %d not found", mobId)
-	}
+func Wander(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	if mob.Character.IsCharmed() {
 		return true, errors.New("friendly mobs don't wander")
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(mob.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, mob.Character.RoomId)
 	}
 
 	// If they aren't home and need to go home, do it.

--- a/usercommands/README.md
+++ b/usercommands/README.md
@@ -3,14 +3,14 @@
 The `usecommands` package defines a function type and contains all of the commands a user can enter.
 
 ```
-type UserCommand func(rest string, userId int) (bool, error)
+type UserCommand func(rest string, user *users.UserRecord) (bool, error)
 ```
 
 All commands follow that definition, where `rest` contains everything except the initial command the user entered, `userId` is who is executing the command.
 
 ```
 
-func Glarble(rest string, userId int) (bool, error) {
+func Glarble(rest string, user *users.UserRecord) (bool, error) {
     
     room.SendText(`This glarble goes out to all players in room`)
     user.SendText(`This glarble goes out to the user`)

--- a/usercommands/README.md
+++ b/usercommands/README.md
@@ -3,14 +3,14 @@
 The `usecommands` package defines a function type and contains all of the commands a user can enter.
 
 ```
-type UserCommand func(rest string, user *users.UserRecord) (bool, error)
+type UserCommand func(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 ```
 
 All commands follow that definition, where `rest` contains everything except the initial command the user entered, `userId` is who is executing the command.
 
 ```
 
-func Glarble(rest string, user *users.UserRecord) (bool, error) {
+func Glarble(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
     
     room.SendText(`This glarble goes out to all players in room`)
     user.SendText(`This glarble goes out to the user`)

--- a/usercommands/admin.badcommands.go
+++ b/usercommands/admin.badcommands.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/volte6/mud/badinputtracker"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func BadCommands(rest string, user *users.UserRecord) (bool, error) {
+func BadCommands(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "clear" {
 		badinputtracker.Clear()

--- a/usercommands/admin.badcommands.go
+++ b/usercommands/admin.badcommands.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func BadCommands(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func BadCommands(rest string, user *users.UserRecord) (bool, error) {
 
 	if rest == "clear" {
 		badinputtracker.Clear()

--- a/usercommands/admin.buff.go
+++ b/usercommands/admin.buff.go
@@ -16,7 +16,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Buff(rest string, user *users.UserRecord) (bool, error) {
+func Buff(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room

--- a/usercommands/admin.buff.go
+++ b/usercommands/admin.buff.go
@@ -16,13 +16,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Buff(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Buff(rest string, user *users.UserRecord) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room
@@ -90,7 +84,7 @@ func Buff(rest string, userId int) (bool, error) {
 				}
 
 			} else if len(args) == 1 {
-				targetUserId = userId
+				targetUserId = user.UserId
 				buffId, _ = strconv.Atoi(args[0])
 				if buffId == 0 {
 					// Grab the first match

--- a/usercommands/admin.build.go
+++ b/usercommands/admin.build.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func IBuild(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func IBuild(rest string, user *users.UserRecord) (bool, error) {
 
 	// args should look like one of the following:
 	// info <optional room id>
@@ -60,7 +54,7 @@ func IBuild(rest string, userId int) (bool, error) {
 				user.SendText(fmt.Sprintf(`Moved to room %d.`, roomId))
 
 				events.AddToQueue(events.Input{
-					UserId:    userId,
+					UserId:    user.UserId,
 					InputText: `look`,
 				}, true)
 
@@ -121,13 +115,7 @@ func IBuild(rest string, userId int) (bool, error) {
 	return true, nil
 }
 
-func Build(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Build(rest string, user *users.UserRecord) (bool, error) {
 
 	// args should look like one of the following:
 	// info <optional room id>
@@ -155,7 +143,7 @@ func Build(rest string, userId int) (bool, error) {
 				} else {
 					user.SendText(fmt.Sprintf("Moved to room %d.", roomId))
 					events.AddToQueue(events.Input{
-						UserId:    userId,
+						UserId:    user.UserId,
 						InputText: `look`,
 					}, true)
 				}
@@ -247,7 +235,7 @@ func Build(rest string, userId int) (bool, error) {
 				user.SendText(fmt.Sprintf("Moved to room %d.", destinationRoom.RoomId))
 
 				events.AddToQueue(events.Input{
-					UserId:    userId,
+					UserId:    user.UserId,
 					InputText: `look`,
 				}, true)
 			}

--- a/usercommands/admin.build.go
+++ b/usercommands/admin.build.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func IBuild(rest string, user *users.UserRecord) (bool, error) {
+func IBuild(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// args should look like one of the following:
 	// info <optional room id>
@@ -115,7 +115,7 @@ func IBuild(rest string, user *users.UserRecord) (bool, error) {
 	return true, nil
 }
 
-func Build(rest string, user *users.UserRecord) (bool, error) {
+func Build(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// args should look like one of the following:
 	// info <optional room id>

--- a/usercommands/admin.command.go
+++ b/usercommands/admin.command.go
@@ -1,7 +1,6 @@
 package usercommands
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/volte6/mud/events"
@@ -13,13 +12,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Command(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Command(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room

--- a/usercommands/admin.command.go
+++ b/usercommands/admin.command.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Command(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Command(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)

--- a/usercommands/admin.locate.go
+++ b/usercommands/admin.locate.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Locate(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Locate(rest string, user *users.UserRecord) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.locate", nil)

--- a/usercommands/admin.locate.go
+++ b/usercommands/admin.locate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Locate(rest string, user *users.UserRecord) (bool, error) {
+func Locate(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.locate", nil)

--- a/usercommands/admin.prepare.go
+++ b/usercommands/admin.prepare.go
@@ -1,20 +1,12 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Prepare(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Prepare(rest string, user *users.UserRecord) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.prepare", nil)

--- a/usercommands/admin.prepare.go
+++ b/usercommands/admin.prepare.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Prepare(rest string, user *users.UserRecord) (bool, error) {
+func Prepare(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.prepare", nil)

--- a/usercommands/admin.questtoken.go
+++ b/usercommands/admin.questtoken.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func QuestToken(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func QuestToken(rest string, user *users.UserRecord) (bool, error) {
 
 	// args should look like one of the following:
 	// questtoken <tokenname>
@@ -80,7 +74,7 @@ func QuestToken(rest string, userId int) (bool, error) {
 	} else {
 
 		events.AddToQueue(events.Quest{
-			UserId:     userId,
+			UserId:     user.UserId,
 			QuestToken: args[0],
 		})
 

--- a/usercommands/admin.questtoken.go
+++ b/usercommands/admin.questtoken.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/volte6/mud/events"
 	"github.com/volte6/mud/quests"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func QuestToken(rest string, user *users.UserRecord) (bool, error) {
+func QuestToken(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// args should look like one of the following:
 	// questtoken <tokenname>

--- a/usercommands/admin.redescribe.go
+++ b/usercommands/admin.redescribe.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Redescribe(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Redescribe(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/usercommands/admin.redescribe.go
+++ b/usercommands/admin.redescribe.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Redescribe(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Redescribe(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -56,7 +50,7 @@ func Redescribe(rest string, userId int) (bool, error) {
 		)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> chants softly and waves their hand over <ansi fg="item">%s</ansi>, causing it to glow briefly.`, user.Character.Name, oldName),
-			userId,
+			user.UserId,
 		)
 	}
 

--- a/usercommands/admin.reload.go
+++ b/usercommands/admin.reload.go
@@ -4,11 +4,12 @@ import (
 	"strings"
 
 	"github.com/volte6/mud/items"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Reload(rest string, user *users.UserRecord) (bool, error) {
+func Reload(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.reload", nil)

--- a/usercommands/admin.reload.go
+++ b/usercommands/admin.reload.go
@@ -1,7 +1,6 @@
 package usercommands
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/volte6/mud/items"
@@ -9,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Reload(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Reload(rest string, user *users.UserRecord) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.reload", nil)

--- a/usercommands/admin.rename.go
+++ b/usercommands/admin.rename.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Rename(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Rename(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/usercommands/admin.rename.go
+++ b/usercommands/admin.rename.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Rename(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Rename(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -60,7 +54,7 @@ func Rename(rest string, userId int) (bool, error) {
 		)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> chants softly and waves their hand over <ansi fg="item">%s</ansi>, causing it to glow briefly.`, user.Character.Name, oldName),
-			userId,
+			user.UserId,
 		)
 	}
 

--- a/usercommands/admin.room.go
+++ b/usercommands/admin.room.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Room(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Room(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -287,7 +281,7 @@ func Room(rest string, userId int) (bool, error) {
 					}
 				}
 
-				Look(`secretly`, userId)
+				Look(`secretly`, user)
 
 				scripting.TryRoomScriptEvent(`onEnter`, user.UserId, gotoRoomId)
 

--- a/usercommands/admin.room.go
+++ b/usercommands/admin.room.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Room(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Room(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	handled := true
 
@@ -281,7 +275,7 @@ func Room(rest string, user *users.UserRecord) (bool, error) {
 					}
 				}
 
-				Look(`secretly`, user)
+				Look(`secretly`, user, room)
 
 				scripting.TryRoomScriptEvent(`onEnter`, user.UserId, gotoRoomId)
 

--- a/usercommands/admin.server.go
+++ b/usercommands/admin.server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/volte6/mud/configs"
 	"github.com/volte6/mud/gametime"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
@@ -19,7 +20,7 @@ var (
 	memoryReportCache = map[string]util.MemoryResult{}
 )
 
-func Server(rest string, user *users.UserRecord) (bool, error) {
+func Server(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.server", nil)

--- a/usercommands/admin.server.go
+++ b/usercommands/admin.server.go
@@ -19,13 +19,7 @@ var (
 	memoryReportCache = map[string]util.MemoryResult{}
 )
 
-func Server(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Server(rest string, user *users.UserRecord) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.server", nil)

--- a/usercommands/admin.skillset.go
+++ b/usercommands/admin.skillset.go
@@ -5,13 +5,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/util"
 
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Skillset(rest string, user *users.UserRecord) (bool, error) {
+func Skillset(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room

--- a/usercommands/admin.skillset.go
+++ b/usercommands/admin.skillset.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Skillset(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Skillset(rest string, user *users.UserRecord) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room

--- a/usercommands/admin.spawn.go
+++ b/usercommands/admin.spawn.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Spawn(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Spawn(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/usercommands/admin.spawn.go
+++ b/usercommands/admin.spawn.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Spawn(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Spawn(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -70,7 +64,7 @@ func Spawn(rest string, userId int) (bool, error) {
 					)
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> waves their hands around and <ansi fg="item">%s</ansi> appears from thin air and falls to the ground.`, user.Character.Name, itm.DisplayName()),
-						userId,
+						user.UserId,
 					)
 
 					return true, nil
@@ -99,7 +93,7 @@ func Spawn(rest string, userId int) (bool, error) {
 			)
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> waves their hands around and <ansi fg="gold">%d gold</ansi> appears from thin air and falls to the ground.`, user.Character.Name, goldAmt),
-				userId,
+				user.UserId,
 			)
 
 			return true, nil
@@ -123,7 +117,7 @@ func Spawn(rest string, userId int) (bool, error) {
 					)
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> waves their hands around and <ansi fg="mobname">%s</ansi> appears in the air and falls to the ground.`, user.Character.Name, mob.Character.Name),
-						userId,
+						user.UserId,
 					)
 
 					return true, nil
@@ -139,7 +133,7 @@ func Spawn(rest string, userId int) (bool, error) {
 	)
 	room.SendText(
 		fmt.Sprintf(`<ansi fg="username">%s</ansi> waves their hands around pathetically.`, user.Character.Name),
-		userId,
+		user.UserId,
 	)
 
 	return true, nil

--- a/usercommands/admin.zap.go
+++ b/usercommands/admin.zap.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Zap(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Zap(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -35,7 +29,7 @@ func Zap(rest string, userId int) (bool, error) {
 	}
 
 	user.SendText(fmt.Sprintf(`You zap <ansi fg="mobname">%s</ansi> with a bolt of lightning!`, mob.Character.Name))
-	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a bolt of lightning!`, user.Character.Name, mob.Character.Name), userId)
+	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a bolt of lightning!`, user.Character.Name, mob.Character.Name), user.UserId)
 	mob.Character.Health = 1
 
 	return true, nil

--- a/usercommands/admin.zap.go
+++ b/usercommands/admin.zap.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Zap(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Zap(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.Aggro == nil || user.Character.Aggro.MobInstanceId == 0 {
 		user.SendText("You are not in combat.")

--- a/usercommands/alias.go
+++ b/usercommands/alias.go
@@ -4,11 +4,12 @@ import (
 	"sort"
 
 	"github.com/volte6/mud/keywords"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Alias(rest string, user *users.UserRecord) (bool, error) {
+func Alias(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// biuld array and look up table for sorting purposes
 	allOutCmds := []string{}

--- a/usercommands/alias.go
+++ b/usercommands/alias.go
@@ -1,7 +1,6 @@
 package usercommands
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/volte6/mud/keywords"
@@ -9,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Alias(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Alias(rest string, user *users.UserRecord) (bool, error) {
 
 	// biuld array and look up table for sorting purposes
 	allOutCmds := []string{}

--- a/usercommands/appraise.go
+++ b/usercommands/appraise.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Appraise(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Appraise(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	for _, mobId := range room.GetMobs(rooms.FindMerchant) {
 

--- a/usercommands/appraise.go
+++ b/usercommands/appraise.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Appraise(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Appraise(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -74,7 +68,7 @@ func Appraise(rest string, userId int) (bool, error) {
 		mob.Character.Gold += appraisePrice
 
 		user.SendText(fmt.Sprintf(`You give <ansi fg="mobname">%s</ansi> %d gold to appraise <ansi fg="itemname">%s</ansi>.`, mob.Character.Name, appraisePrice, itemSpec.Name))
-		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> appraises <ansi fg="itemname">%s</ansi>.`, user.Character.Name, itemSpec.Name), userId)
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> appraises <ansi fg="itemname">%s</ansi>.`, user.Character.Name, itemSpec.Name), user.UserId)
 
 		inspectTxt, _ := templates.Process("descriptions/inspect", details)
 		user.SendText(inspectTxt)

--- a/usercommands/ask.go
+++ b/usercommands/ask.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Ask(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Ask(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Core "useful" commands
 	usefulCommands := []string{

--- a/usercommands/ask.go
+++ b/usercommands/ask.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Ask(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Ask(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -61,7 +55,7 @@ func Ask(rest string, userId int) (bool, error) {
 			if mob == nil {
 				continue
 			}
-			if mob.Character.IsCharmed(userId) {
+			if mob.Character.IsCharmed(user.UserId) {
 
 				mob.Command(fmt.Sprintf(`say I can do a few useful things, such as %s`,
 					fmt.Sprintf(`<ansi fg="command">%s</ansi>`, strings.Join(usefulCommands, `</ansi>, <ansi fg="command">`))))
@@ -106,7 +100,7 @@ func Ask(rest string, userId int) (bool, error) {
 			args = args[1:]
 		}
 
-		if mob.Character.IsCharmed(userId) {
+		if mob.Character.IsCharmed(user.UserId) {
 
 			mobCmd := args[0]
 			askRest := strings.Join(args[1:], ` `)
@@ -138,7 +132,7 @@ func Ask(rest string, userId int) (bool, error) {
 		}
 
 		rest = strings.Join(args, ` `)
-		if handled, err := scripting.TryMobScriptEvent(`onAsk`, mobId, userId, `user`, map[string]any{"askText": rest}); err == nil {
+		if handled, err := scripting.TryMobScriptEvent(`onAsk`, mobId, user.UserId, `user`, map[string]any{"askText": rest}); err == nil {
 
 			if !handled {
 				mob.Command(`emote shakes their head.`)

--- a/usercommands/attack.go
+++ b/usercommands/attack.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Attack(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Attack(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -39,7 +33,7 @@ func Attack(rest string, userId int) (bool, error) {
 				continue
 			}
 
-			if m.Character.Aggro.UserId == userId {
+			if m.Character.Aggro.UserId == user.UserId {
 				attackMobInstanceId = m.InstanceId
 				break
 			}
@@ -59,7 +53,7 @@ func Attack(rest string, userId int) (bool, error) {
 					continue
 				}
 
-				if u.Character.Aggro.UserId == userId {
+				if u.Character.Aggro.UserId == user.UserId {
 					attackPlayerId = u.UserId
 					break
 				}
@@ -101,7 +95,7 @@ func Attack(rest string, userId int) (bool, error) {
 		attackPlayerId, attackMobInstanceId = room.FindByName(rest)
 	}
 
-	if attackPlayerId == userId { // Can't attack self!
+	if attackPlayerId == user.UserId { // Can't attack self!
 		attackPlayerId = 0
 	}
 
@@ -125,7 +119,7 @@ func Attack(rest string, userId int) (bool, error) {
 		m := mobs.GetInstance(attackMobInstanceId)
 
 		if m != nil {
-			if m.Character.IsCharmed(userId) {
+			if m.Character.IsCharmed(user.UserId) {
 				user.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> is your friend!`, m.Character.Name))
 				return true, nil
 			}
@@ -157,13 +151,13 @@ func Attack(rest string, userId int) (bool, error) {
 			if !isSneaking {
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>`, user.Character.Name, m.Character.Name),
-					userId,
+					user.UserId,
 				)
 			}
 
 			for _, instId := range room.GetMobs(rooms.FindCharmed) {
 				if m := mobs.GetInstance(instId); m != nil {
-					if m.Character.Aggro == nil && m.Character.IsCharmed(userId) { // Charmed mobs help the player
+					if m.Character.Aggro == nil && m.Character.IsCharmed(user.UserId) { // Charmed mobs help the player
 
 						m.Command(fmt.Sprintf(`attack #%d`, attackMobInstanceId)) // # denotes a specific mob instanceId
 
@@ -220,12 +214,12 @@ func Attack(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>`, user.Character.Name, p.Character.Name),
-					userId, attackPlayerId)
+					user.UserId, attackPlayerId)
 			}
 
 			for _, instId := range room.GetMobs(rooms.FindCharmed) {
 				if m := mobs.GetInstance(instId); m != nil {
-					if m.Character.Aggro == nil && m.Character.IsCharmed(userId) { // Charmed mobs help the player
+					if m.Character.Aggro == nil && m.Character.IsCharmed(user.UserId) { // Charmed mobs help the player
 
 						m.Command(fmt.Sprintf(`attack @%d`, attackPlayerId)) // @ denotes a specific user id
 

--- a/usercommands/attack.go
+++ b/usercommands/attack.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Attack(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Attack(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	attackPlayerId := 0
 	attackMobInstanceId := 0

--- a/usercommands/auction.go
+++ b/usercommands/auction.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	"github.com/volte6/mud/auctions"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Auction(rest string, user *users.UserRecord) (bool, error) {
+func Auction(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if on := user.GetConfigOption(`auction`); on != nil && !on.(bool) {
 

--- a/usercommands/auction.go
+++ b/usercommands/auction.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Auction(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Auction(rest string, user *users.UserRecord) (bool, error) {
 
 	if on := user.GetConfigOption(`auction`); on != nil && !on.(bool) {
 
@@ -91,12 +85,12 @@ func Auction(rest string, userId int) (bool, error) {
 			return true, nil
 		}
 
-		if currentAuction.SellerUserId == userId {
+		if currentAuction.SellerUserId == user.UserId {
 			user.SendText(`You cannot bid on your own auction.`)
 			return true, nil
 		}
 
-		if currentAuction.HighestBidUserId == userId {
+		if currentAuction.HighestBidUserId == user.UserId {
 			user.SendText(`You are already the highest bidder.`)
 			return true, nil
 		}
@@ -122,7 +116,7 @@ func Auction(rest string, userId int) (bool, error) {
 			return true, nil
 		}
 
-		if err := auctions.Bid(userId, amt); err != nil {
+		if err := auctions.Bid(user.UserId, amt); err != nil {
 			user.SendText(err.Error())
 			return true, nil
 		}
@@ -185,7 +179,7 @@ func Auction(rest string, userId int) (bool, error) {
 
 	user.SendText(fmt.Sprintf("Auctioning your <ansi fg=\"item\">%s</ansi> for <ansi fg=\"gold\">%d gold</ansi>.", matchItem.DisplayName(), amt))
 
-	if auctions.StartAuction(matchItem, userId, amt) {
+	if auctions.StartAuction(matchItem, user.UserId, amt) {
 		user.Character.RemoveItem(matchItem)
 	}
 

--- a/usercommands/bank.go
+++ b/usercommands/bank.go
@@ -11,14 +11,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Bank(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Bank(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	user.SendText(``)
 

--- a/usercommands/bank.go
+++ b/usercommands/bank.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Bank(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Bank(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 

--- a/usercommands/biome.go
+++ b/usercommands/biome.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Biome(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Biome(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)

--- a/usercommands/biome.go
+++ b/usercommands/biome.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Biome(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Biome(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	biome, ok := rooms.GetBiome(room.Biome)
 

--- a/usercommands/break.go
+++ b/usercommands/break.go
@@ -7,13 +7,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Break(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Break(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -26,7 +20,7 @@ func Break(rest string, userId int) (bool, error) {
 		user.SendText(`You break off combat.`)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> breaks off combat.`, user.Character.Name),
-			userId,
+			user.UserId,
 		)
 	} else {
 		user.SendText(`You aren't in combat!`)

--- a/usercommands/break.go
+++ b/usercommands/break.go
@@ -7,13 +7,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Break(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Break(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.Aggro != nil {
 		user.Character.Aggro = nil

--- a/usercommands/broadcast.go
+++ b/usercommands/broadcast.go
@@ -9,13 +9,7 @@ import (
 )
 
 // Global chat room
-func Broadcast(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Broadcast(rest string, user *users.UserRecord) (bool, error) {
 
 	events.AddToQueue(events.Broadcast{
 		Text: fmt.Sprintf(`<ansi fg="black-bold">(broadcast)</ansi> <ansi fg="username">%s</ansi>: <ansi fg="yellow">%s</ansi>%s`, user.Character.Name, rest, term.CRLFStr),

--- a/usercommands/broadcast.go
+++ b/usercommands/broadcast.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/volte6/mud/events"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/term"
 	"github.com/volte6/mud/users"
 )
 
 // Global chat room
-func Broadcast(rest string, user *users.UserRecord) (bool, error) {
+func Broadcast(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	events.AddToQueue(events.Broadcast{
 		Text: fmt.Sprintf(`<ansi fg="black-bold">(broadcast)</ansi> <ansi fg="username">%s</ansi>: <ansi fg="yellow">%s</ansi>%s`, user.Character.Name, rest, term.CRLFStr),

--- a/usercommands/buy.go
+++ b/usercommands/buy.go
@@ -16,16 +16,10 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Buy(rest string, userId int) (bool, error) {
+func Buy(rest string, user *users.UserRecord) (bool, error) {
 
 	if rest == "" {
-		return List(rest, userId)
-	}
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
+		return List(rest, user)
 	}
 
 	// Load current room details
@@ -45,7 +39,7 @@ func Buy(rest string, userId int) (bool, error) {
 		if args[len(args)-2] == `from` {
 			targetUserId, targetMobInstanceId = room.FindByName(args[len(args)-1])
 
-			if userId == targetUserId {
+			if user.UserId == targetUserId {
 				user.SendText("You can't buy from yourself.")
 				return true, nil
 			}

--- a/usercommands/buy.go
+++ b/usercommands/buy.go
@@ -16,16 +16,10 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Buy(rest string, user *users.UserRecord) (bool, error) {
+func Buy(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "" {
-		return List(rest, user)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
+		return List(rest, user, room)
 	}
 
 	targetMobInstanceId := 0

--- a/usercommands/character.go
+++ b/usercommands/character.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/volte6/mud/characters"
 	"github.com/volte6/mud/configs"
@@ -16,15 +15,10 @@ import (
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/term"
 	"github.com/volte6/mud/users"
+	"github.com/volte6/mud/util"
 )
 
-func Character(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Character(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -43,18 +37,16 @@ func Character(rest string, userId int) (bool, error) {
 
 	/*
 		user.Character = characters.New()
-		rooms.MoveToRoom(userId, -1)
+		rooms.MoveToRoom(user.UserId, -1)
 	*/
 
-	config := configs.GetConfig()
-
-	if config.MaxAltCharacters == 0 {
-		user.SendText(`Alt character are disabled on this server.`)
+	if configs.GetConfig().MaxAltCharacters == 0 {
+		user.SendText(`<ansi fg="203">Alt character are disabled on this server.</ansi>`)
 		return true, errors.New(`alt characters disabled`)
 	}
 
 	if user.Character.Level < 5 {
-		user.SendText(`You must reach level 5 with this character to access character alts.`)
+		user.SendText(`<ansi fg="203">You must reach level 5 with this character to access character alts.</ansi>`)
 		return true, errors.New(`level 5 minimum`)
 	}
 
@@ -62,11 +54,17 @@ func Character(rest string, userId int) (bool, error) {
 
 	cmdPrompt, isNew := user.StartPrompt(`character`, rest)
 
-	alts := characters.LoadAlts(user.Username)
+	altNames := []string{}
+	nameToAlt := map[string]characters.Character{}
+
+	for _, char := range characters.LoadAlts(user.Username) {
+		altNames = append(altNames, char.Name)
+		nameToAlt[char.Name] = char
+	}
 
 	if isNew {
 
-		if len(alts) > 0 {
+		if len(altNames) > 0 {
 			menuOptions = append(menuOptions, `view`)
 			menuOptions = append(menuOptions, `change`)
 			menuOptions = append(menuOptions, `delete`)
@@ -76,40 +74,10 @@ func Character(rest string, userId int) (bool, error) {
 			}
 		}
 
-		if len(alts) > 0 {
-
-			headers := []string{"Name", "Level", "Race", "Profession", "Alignment"}
-			rows := [][]string{}
-
-			for _, char := range alts {
-
-				allRanks := char.GetAllSkillRanks()
-				raceName := `Unknown`
-				if raceInfo := races.GetRace(char.RaceId); raceInfo != nil {
-					raceName = raceInfo.Name
-				}
-
-				rows = append(rows, []string{
-					fmt.Sprintf(`<ansi fg="username">%s</ansi>`, char.Name),
-					strconv.Itoa(char.Level),
-					raceName,
-					skills.GetProfession(allRanks),
-					fmt.Sprintf(`<ansi fg="%s">%s</ansi>`, char.AlignmentName(), char.AlignmentName()),
-				})
-
-			}
-
-			sort.Slice(rows, func(i, j int) bool {
-				num1, _ := strconv.Atoi(rows[i][1])
-				num2, _ := strconv.Atoi(rows[j][1])
-				return num1 < num2
-			})
-
-			characters.SaveAlts(user.Username, alts)
-			altTableData := templates.GetTable(fmt.Sprintf(`Your alt characters (%d/%d)`, len(alts), config.MaxAltCharacters), headers, rows)
-			tplTxt, _ := templates.Process("tables/generic", altTableData)
+		if len(nameToAlt) > 0 {
+			altTblTxt := getAltTable(nameToAlt)
 			user.SendText(``)
-			user.SendText(tplTxt)
+			user.SendText(altTblTxt)
 		}
 
 	}
@@ -134,15 +102,15 @@ func Character(rest string, userId int) (bool, error) {
 	/////////////////////////
 	if question.Response == `new` {
 
-		if len(alts) >= int(config.MaxAltCharacters) {
-			user.SendText(`You already have too many alts.`)
-			user.SendText(`You'll need to delete one to create a new one.`)
+		if len(altNames) >= int(configs.GetConfig().MaxAltCharacters) {
+			user.SendText(`<ansi fg="203">You already have too many alts.</ansi>`)
+			user.SendText(`<ansi fg="203">You'll need to delete one to create a new one.</ansi>`)
 
 			question.RejectResponse()
 			return true, nil
 		}
 
-		question := cmdPrompt.Ask(`Are you SURE? Your current character will be saved here to change back to later.`, []string{`yes`, `no`}, `no`)
+		question := cmdPrompt.Ask(`Are you SURE? (Your current character will be saved here to change back to later)`, []string{`yes`, `no`}, `no`)
 		if !question.Done {
 			return true, nil
 		}
@@ -152,12 +120,16 @@ func Character(rest string, userId int) (bool, error) {
 			return true, nil
 		}
 
-		alts = append(alts, *user.Character)
-		characters.SaveAlts(user.Username, alts)
+		newAlts := []characters.Character{}
+		for _, char := range nameToAlt {
+			newAlts = append(newAlts, char)
+		}
+		newAlts = append(newAlts, *user.Character)
+		characters.SaveAlts(user.Username, newAlts)
 
 		// Send them back to start with a fresh/empty character
 		user.Character = characters.New()
-		rooms.MoveToRoom(userId, -1)
+		rooms.MoveToRoom(user.UserId, -1)
 
 	}
 
@@ -166,34 +138,52 @@ func Character(rest string, userId int) (bool, error) {
 	/////////////////////////
 	if question.Response == `delete` {
 
-		question := cmdPrompt.Ask(`Enter the name of the character you wish to delete.`, []string{})
-
-		for i, char := range alts {
-			if strings.EqualFold(char.Name, question.Response) {
-
-				question := cmdPrompt.Ask(`<ansi fg="red">Are you SURE you want to delete <ansi fg="username">`+char.Name+`</ansi>?</ansi>`, []string{`yes`, `no`}, `no`)
-				if !question.Done {
-					return true, nil
-				}
-
-				if question.Response == `no` {
-					user.SendText(`Okay. Aborting.`)
-					user.ClearPrompt()
-					return true, nil
-				}
-
-				alts = append(alts[:i], alts[i+1:]...)
-
-				characters.SaveAlts(user.Username, alts)
-
-				user.SendText(`<ansi fg="username">` + char.Name + `</ansi> <ansi fg="red">is deleted.</ansi>`)
-				user.ClearPrompt()
-				return true, nil
-
-			}
+		if len(nameToAlt) > 0 {
+			altTblTxt := getAltTable(nameToAlt)
+			user.SendText(``)
+			user.SendText(altTblTxt)
 		}
 
-		user.SendText(`No character with that name found.`)
+		question := cmdPrompt.Ask(`Enter the name of the character you wish to delete:`, []string{})
+		if !question.Done {
+			return true, nil
+		}
+
+		match, closeMatch := util.FindMatchIn(question.Response, altNames...)
+		if match == `` {
+			match = closeMatch
+		}
+
+		if match != `` {
+
+			delChar := nameToAlt[match]
+
+			question := cmdPrompt.Ask(`<ansi fg="red">Are you SURE you want to delete <ansi fg="username">`+delChar.Name+`</ansi>?</ansi>`, []string{`yes`, `no`}, `no`)
+			if !question.Done {
+				return true, nil
+			}
+
+			if question.Response == `no` {
+				user.SendText(`<ansi fg="203">Okay. Aborting.</ansi>`)
+				user.ClearPrompt()
+				return true, nil
+			}
+
+			newAlts := []characters.Character{}
+			for _, char := range nameToAlt {
+				if char.Name != match {
+					newAlts = append(newAlts, char)
+				}
+			}
+			characters.SaveAlts(user.Username, newAlts)
+
+			user.SendText(`<ansi fg="username">` + match + `</ansi> <ansi fg="red">is deleted.</ansi>`)
+			user.ClearPrompt()
+			return true, nil
+
+		}
+
+		user.SendText(`<ansi fg="203">No character with the name <ansi fg="username">` + question.Response + `</ansi> found.</ansi>`)
 
 		user.ClearPrompt()
 		return true, nil
@@ -205,46 +195,64 @@ func Character(rest string, userId int) (bool, error) {
 	/////////////////////////
 	if question.Response == `change` {
 
-		question := cmdPrompt.Ask(`Enter the name of the character you wish to change to.`, []string{})
+		if len(nameToAlt) > 0 {
+			altTblTxt := getAltTable(nameToAlt)
+			user.SendText(``)
+			user.SendText(altTblTxt)
+		}
+
+		question := cmdPrompt.Ask(`Enter the name of the character you wish to change to:`, []string{})
 		if !question.Done {
 			return true, nil
 		}
 
-		for i, char := range alts {
-			if strings.EqualFold(char.Name, question.Response) {
-
-				question := cmdPrompt.Ask(`<ansi fg="51">Are you SURE you want to change to <ansi fg="username">`+char.Name+`</ansi>?</ansi>`, []string{`yes`, `no`}, `no`)
-				if !question.Done {
-					return true, nil
-				}
-
-				if question.Response == `no` {
-					user.SendText(`Okay. Aborting.`)
-					user.ClearPrompt()
-					return true, nil
-				}
-
-				oldName := user.Character.Name
-
-				alts = append(alts[:i], alts[i+1:]...)
-				alts = append(alts, *user.Character)
-				user.Character = &char
-
-				user.Character.Validate()
-
-				characters.SaveAlts(user.Username, alts)
-				users.SaveUser(*user)
-
-				user.SendText(term.CRLFStr + `You dematerialize as <ansi fg="username">` + oldName + `</ansi>. and rematerialize as <ansi fg="username">` + char.Name + `</ansi>!` + term.CRLFStr)
-				room.SendText(`<ansi fg="username">`+oldName+`</ansi> vanishes, and <ansi fg="username">`+char.Name+`</ansi> appears in a shower of sparks!`, user.UserId)
-
-				user.ClearPrompt()
-				return true, nil
-
-			}
+		match, closeMatch := util.FindMatchIn(question.Response, altNames...)
+		if match == `` {
+			match = closeMatch
 		}
 
-		user.SendText(`No character with that name found.`)
+		if match != `` {
+
+			char := nameToAlt[match]
+
+			question := cmdPrompt.Ask(`<ansi fg="51">Are you SURE you want to change to <ansi fg="username">`+char.Name+`</ansi>?</ansi>`, []string{`yes`, `no`}, `no`)
+			if !question.Done {
+				return true, nil
+			}
+
+			if question.Response == `no` {
+				user.SendText(`<ansi fg="203">Okay. Aborting.</ansi>`)
+				user.ClearPrompt()
+				return true, nil
+			}
+
+			oldName := user.Character.Name
+
+			newAlts := []characters.Character{}
+			for _, c := range nameToAlt {
+				if c.Name != match {
+					newAlts = append(newAlts, c)
+				}
+			}
+			newAlts = append(newAlts, *user.Character)
+			characters.SaveAlts(user.Username, newAlts)
+
+			char.Validate()
+			user.Character = &char
+
+			user.Character.RoomId = room.RoomId
+
+			users.SaveUser(*user)
+
+			user.SendText(term.CRLFStr + `You dematerialize as <ansi fg="username">` + oldName + `</ansi>. and rematerialize as <ansi fg="username">` + char.Name + `</ansi>!` + term.CRLFStr)
+			room.SendText(`<ansi fg="username">`+oldName+`</ansi> vanishes, and <ansi fg="username">`+char.Name+`</ansi> appears in a shower of sparks!`, user.UserId)
+
+			user.ClearPrompt()
+			return true, nil
+
+		}
+
+		user.SendText(`<ansi fg="203">No character with the name <ansi fg="username">` + question.Response + `</ansi> found.</ansi>`)
 
 		user.ClearPrompt()
 		return true, nil
@@ -256,35 +264,46 @@ func Character(rest string, userId int) (bool, error) {
 	/////////////////////////
 	if question.Response == `view` {
 
-		question := cmdPrompt.Ask(`Enter the name of the character you wish to view.`, []string{})
+		if len(nameToAlt) > 0 {
+			altTblTxt := getAltTable(nameToAlt)
+			user.SendText(``)
+			user.SendText(altTblTxt)
+		}
+
+		question := cmdPrompt.Ask(`Enter the name of the character you wish to view:`, []string{})
 		if !question.Done {
 			return true, nil
 		}
 
-		for _, char := range alts {
-			if strings.EqualFold(char.Name, question.Response) {
-
-				char.Validate()
-
-				tmpChar := user.Character
-				user.Character = &char
-
-				Status(``, user.UserId)
-
-				user.Character = tmpChar
-
-				m := mobs.NewMobById(59, user.Character.RoomId)
-				m.Character = char
-				room.AddMob(m.InstanceId)
-				m.Character.Charm(user.UserId, -1, `suicide vanish`)
-
-				user.ClearPrompt()
-				return true, nil
-
-			}
+		match, closeMatch := util.FindMatchIn(question.Response, altNames...)
+		if match == `` {
+			match = closeMatch
 		}
 
-		user.SendText(`No character with that name found.`)
+		if match != `` {
+
+			char := nameToAlt[match]
+
+			char.Validate()
+
+			tmpChar := user.Character
+			user.Character = &char
+
+			Status(``, user)
+
+			user.Character = tmpChar
+
+			m := mobs.NewMobById(59, user.Character.RoomId)
+			m.Character = char
+			room.AddMob(m.InstanceId)
+			m.Character.Charm(user.UserId, -1, `suicide vanish`)
+
+			user.ClearPrompt()
+			return true, nil
+
+		}
+
+		user.SendText(`<ansi fg="203">No character with the name <ansi fg="username">` + question.Response + `</ansi> found.</ansi>`)
 
 		user.ClearPrompt()
 		return true, nil
@@ -292,37 +311,48 @@ func Character(rest string, userId int) (bool, error) {
 	}
 
 	/////////////////////////
-	// Spawn a helper clone
+	// Spawn a helper clone - experimental
 	/////////////////////////
 	if question.Response == `hire` {
 
-		question := cmdPrompt.Ask(`Enter the name of the character you wish to hire.`, []string{})
+		if len(nameToAlt) > 0 {
+			altTblTxt := getAltTable(nameToAlt)
+			user.SendText(``)
+			user.SendText(altTblTxt)
+		}
+
+		question := cmdPrompt.Ask(`Enter the name of the character you wish to hire:`, []string{})
 		if !question.Done {
 			return true, nil
 		}
 
-		for _, char := range alts {
-			if strings.EqualFold(char.Name, question.Response) {
-
-				char.Validate()
-
-				m := mobs.NewMobById(59, user.Character.RoomId)
-				m.Character = char
-				room.AddMob(m.InstanceId)
-				m.Character.Charm(user.UserId, -1, `suicide vanish`)
-
-				user.SendText(`<ansi fg="username">` + m.Character.Name + `</ansi> appears to help you out!`)
-				room.SendText(`<ansi fg="username">`+m.Character.Name+`</ansi> appears to help <ansi fg="username">`+user.Character.Name+`</ansi>!`, user.UserId)
-
-				m.Command(`emote waves sheepishly.`, 2)
-
-				user.ClearPrompt()
-				return true, nil
-
-			}
+		match, closeMatch := util.FindMatchIn(question.Response, altNames...)
+		if match == `` {
+			match = closeMatch
 		}
 
-		user.SendText(`No character with that name found.`)
+		if match != `` {
+
+			char := nameToAlt[match]
+
+			char.Validate()
+
+			m := mobs.NewMobById(59, user.Character.RoomId)
+			m.Character = char
+			room.AddMob(m.InstanceId)
+			m.Character.Charm(user.UserId, -1, `suicide vanish`)
+
+			user.SendText(`<ansi fg="username">` + m.Character.Name + `</ansi> appears to help you out!`)
+			room.SendText(`<ansi fg="username">`+m.Character.Name+`</ansi> appears to help <ansi fg="username">`+user.Character.Name+`</ansi>!`, user.UserId)
+
+			m.Command(`emote waves sheepishly.`, 2)
+
+			user.ClearPrompt()
+			return true, nil
+
+		}
+
+		user.SendText(`<ansi fg="203">No character with the name <ansi fg="username">` + question.Response + `</ansi> found.</ansi>`)
 
 		user.ClearPrompt()
 		return true, nil
@@ -330,4 +360,39 @@ func Character(rest string, userId int) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func getAltTable(nameToAlt map[string]characters.Character) string {
+
+	headers := []string{"Name", "Level", "Race", "Profession", "Alignment"}
+	rows := [][]string{}
+
+	for _, char := range nameToAlt {
+
+		allRanks := char.GetAllSkillRanks()
+		raceName := `Unknown`
+		if raceInfo := races.GetRace(char.RaceId); raceInfo != nil {
+			raceName = raceInfo.Name
+		}
+
+		rows = append(rows, []string{
+			fmt.Sprintf(`<ansi fg="username">%s</ansi>`, char.Name),
+			strconv.Itoa(char.Level),
+			raceName,
+			skills.GetProfession(allRanks),
+			fmt.Sprintf(`<ansi fg="%s">%s</ansi>`, char.AlignmentName(), char.AlignmentName()),
+		})
+
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		num1, _ := strconv.Atoi(rows[i][1])
+		num2, _ := strconv.Atoi(rows[j][1])
+		return num1 < num2
+	})
+
+	altTableData := templates.GetTable(fmt.Sprintf(`Your alt characters (%d/%d)`, len(nameToAlt), configs.GetConfig().MaxAltCharacters), headers, rows)
+	tplTxt, _ := templates.Process("tables/generic", altTableData)
+
+	return tplTxt
 }

--- a/usercommands/character.go
+++ b/usercommands/character.go
@@ -18,13 +18,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Character(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Character(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if !room.IsCharacterRoom {
 		return false, fmt.Errorf(`not in a IsCharacterRoom`)
@@ -289,7 +283,7 @@ func Character(rest string, user *users.UserRecord) (bool, error) {
 			tmpChar := user.Character
 			user.Character = &char
 
-			Status(``, user)
+			Status(``, user, room)
 
 			user.Character = tmpChar
 

--- a/usercommands/conditions.go
+++ b/usercommands/conditions.go
@@ -4,11 +4,12 @@ import (
 	"math"
 
 	"github.com/volte6/mud/buffs"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Conditions(rest string, user *users.UserRecord) (bool, error) {
+func Conditions(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	type buffInfo struct {
 		Name        string

--- a/usercommands/conditions.go
+++ b/usercommands/conditions.go
@@ -1,7 +1,6 @@
 package usercommands
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/volte6/mud/buffs"
@@ -9,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Conditions(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Conditions(rest string, user *users.UserRecord) (bool, error) {
 
 	type buffInfo struct {
 		Name        string

--- a/usercommands/consider.go
+++ b/usercommands/consider.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Consider(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Consider(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/usercommands/consider.go
+++ b/usercommands/consider.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Consider(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Consider(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -35,7 +29,7 @@ func Consider(rest string, userId int) (bool, error) {
 		//
 
 		playerId, mobId := room.FindByName(lookAt)
-		if playerId == userId {
+		if playerId == user.UserId {
 			playerId = 0
 		}
 

--- a/usercommands/cooldowns.go
+++ b/usercommands/cooldowns.go
@@ -1,19 +1,11 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Cooldowns(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Cooldowns(rest string, user *users.UserRecord) (bool, error) {
 
 	cdTxt, _ := templates.Process("character/cooldowns", user.Character.GetAllCooldowns())
 	user.SendText(cdTxt)

--- a/usercommands/cooldowns.go
+++ b/usercommands/cooldowns.go
@@ -1,11 +1,12 @@
 package usercommands
 
 import (
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Cooldowns(rest string, user *users.UserRecord) (bool, error) {
+func Cooldowns(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	cdTxt, _ := templates.Process("character/cooldowns", user.Character.GetAllCooldowns())
 	user.SendText(cdTxt)

--- a/usercommands/drink.go
+++ b/usercommands/drink.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Drink(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Drink(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/usercommands/drink.go
+++ b/usercommands/drink.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Drink(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Drink(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -45,7 +39,7 @@ func Drink(rest string, userId int) (bool, error) {
 		user.Character.UseItem(matchItem)
 
 		user.SendText(fmt.Sprintf(`You drink the <ansi fg="itemname">%s</ansi>.`, matchItem.DisplayName()))
-		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> drinks <ansi fg="itemname">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()), userId)
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> drinks <ansi fg="itemname">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()), user.UserId)
 
 		for _, buffId := range itemSpec.BuffIds {
 

--- a/usercommands/drop.go
+++ b/usercommands/drop.go
@@ -15,13 +15,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Drop(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Drop(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -42,13 +36,13 @@ func Drop(rest string, userId int) (bool, error) {
 		iCopies := []items.Item{}
 
 		if user.Character.Gold > 0 {
-			Drop(fmt.Sprintf("%d gold", user.Character.Gold), userId)
+			Drop(fmt.Sprintf("%d gold", user.Character.Gold), user)
 		}
 
 		iCopies = append(iCopies, user.Character.Items...)
 
 		for _, item := range iCopies {
-			Drop(item.Name(), userId)
+			Drop(item.Name(), user)
 		}
 
 		return true, nil
@@ -77,7 +71,7 @@ func Drop(rest string, userId int) (bool, error) {
 		)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> drops <ansi fg="gold">%d gold</ansi>.`, user.Character.Name, dropAmt),
-			userId,
+			user.UserId,
 		)
 
 		return true, nil
@@ -102,7 +96,7 @@ func Drop(rest string, userId int) (bool, error) {
 		)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> drops their <ansi fg="item">%s</ansi>...`, user.Character.Name, matchItem.DisplayName()),
-			userId,
+			user.UserId,
 		)
 
 		// If grenades are dropped, they explode and affect everyone in the room!
@@ -123,7 +117,7 @@ func Drop(rest string, userId int) (bool, error) {
 		room.AddItem(matchItem, false)
 
 		// Trigger onLost event
-		scripting.TryItemScriptEvent(`onLost`, matchItem, userId)
+		scripting.TryItemScriptEvent(`onLost`, matchItem, user.UserId)
 	}
 
 	return true, nil

--- a/usercommands/drop.go
+++ b/usercommands/drop.go
@@ -15,13 +15,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Drop(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Drop(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
@@ -36,13 +30,13 @@ func Drop(rest string, user *users.UserRecord) (bool, error) {
 		iCopies := []items.Item{}
 
 		if user.Character.Gold > 0 {
-			Drop(fmt.Sprintf("%d gold", user.Character.Gold), user)
+			Drop(fmt.Sprintf("%d gold", user.Character.Gold), user, room)
 		}
 
 		iCopies = append(iCopies, user.Character.Items...)
 
 		for _, item := range iCopies {
-			Drop(item.Name(), user)
+			Drop(item.Name(), user, room)
 		}
 
 		return true, nil

--- a/usercommands/eat.go
+++ b/usercommands/eat.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Eat(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Eat(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/usercommands/eat.go
+++ b/usercommands/eat.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Eat(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Eat(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -44,11 +38,11 @@ func Eat(rest string, userId int) (bool, error) {
 		user.Character.CancelBuffsWithFlag(buffs.Hidden)
 
 		user.SendText(fmt.Sprintf(`You eat some of the <ansi fg="itemname">%s</ansi>.`, matchItem.DisplayName()))
-		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> eats some <ansi fg="itemname">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()), userId)
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> eats some <ansi fg="itemname">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()), user.UserId)
 
 		// If no more uses, will be lost, so trigger event
 		if usesLeft := user.Character.UseItem(matchItem); usesLeft < 1 {
-			scripting.TryItemScriptEvent(`onLost`, matchItem, userId)
+			scripting.TryItemScriptEvent(`onLost`, matchItem, user.UserId)
 		}
 
 		for _, buffId := range itemSpec.BuffIds {

--- a/usercommands/emote.go
+++ b/usercommands/emote.go
@@ -92,13 +92,7 @@ var (
 	}
 )
 
-func Emote(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Emote(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -110,7 +104,7 @@ func Emote(rest string, userId int) (bool, error) {
 		user.SendText("You emote.")
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> emotes.`, user.Character.Name),
-			userId,
+			user.UserId,
 		)
 		return true, nil
 	}
@@ -123,7 +117,7 @@ func Emote(rest string, userId int) (bool, error) {
 
 	room.SendText(
 		fmt.Sprintf(`<ansi fg="username">%s</ansi> <ansi fg="20">%s</ansi>`, user.Character.Name, rest),
-		userId,
+		user.UserId,
 	)
 
 	return true, nil

--- a/usercommands/emote.go
+++ b/usercommands/emote.go
@@ -92,13 +92,7 @@ var (
 	}
 )
 
-func Emote(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Emote(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if len(rest) == 0 {
 		user.SendText("You emote.")

--- a/usercommands/equip.go
+++ b/usercommands/equip.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Equip(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Equip(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -25,12 +19,12 @@ func Equip(rest string, userId int) (bool, error) {
 	}
 
 	if rest == "all" {
-		return Gearup(``, userId)
+		return Gearup(``, user)
 		itemCopies := append([]items.Item{}, user.Character.Items...)
 		for _, item := range itemCopies {
 			iSpec := item.GetSpec()
 			if iSpec.Subtype == items.Wearable || iSpec.Type == items.Weapon {
-				Equip(item.Name(), userId)
+				Equip(item.Name(), user)
 			}
 		}
 		return true, nil
@@ -67,7 +61,7 @@ func Equip(rest string, userId int) (bool, error) {
 					)
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> removes their <ansi fg="item">%s</ansi> and stores it away.`, user.Character.Name, oldItem.DisplayName()),
-						userId,
+						user.UserId,
 					)
 
 					user.Character.StoreItem(oldItem)
@@ -80,7 +74,7 @@ func Equip(rest string, userId int) (bool, error) {
 				)
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> puts on their <ansi fg="item">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()),
-					userId,
+					user.UserId,
 				)
 			} else {
 				user.SendText(
@@ -88,7 +82,7 @@ func Equip(rest string, userId int) (bool, error) {
 				)
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> wields their <ansi fg="item">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()),
-					userId,
+					user.UserId,
 				)
 			}
 

--- a/usercommands/equip.go
+++ b/usercommands/equip.go
@@ -10,21 +10,15 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Equip(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Equip(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "all" {
-		return Gearup(``, user)
+		return Gearup(``, user, room)
 		itemCopies := append([]items.Item{}, user.Character.Items...)
 		for _, item := range itemCopies {
 			iSpec := item.GetSpec()
 			if iSpec.Subtype == items.Wearable || iSpec.Type == items.Weapon {
-				Equip(item.Name(), user)
+				Equip(item.Name(), user, room)
 			}
 		}
 		return true, nil

--- a/usercommands/exits.go
+++ b/usercommands/exits.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Exits(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Exits(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)

--- a/usercommands/exits.go
+++ b/usercommands/exits.go
@@ -1,20 +1,12 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Exits(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Exits(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	details := room.GetRoomDetails(user)
 

--- a/usercommands/experience.go
+++ b/usercommands/experience.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Experience(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Experience(rest string, user *users.UserRecord) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/usercommands/experience.go
+++ b/usercommands/experience.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/volte6/mud/characters"
 	"github.com/volte6/mud/races"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Experience(rest string, user *users.UserRecord) (bool, error) {
+func Experience(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/usercommands/flee.go
+++ b/usercommands/flee.go
@@ -1,19 +1,11 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/characters"
 	"github.com/volte6/mud/users"
 )
 
-func Flee(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Flee(rest string, user *users.UserRecord) (bool, error) {
 
 	if user.Character.Aggro == nil {
 		user.SendText(`You aren't in combat!`)

--- a/usercommands/flee.go
+++ b/usercommands/flee.go
@@ -2,10 +2,11 @@ package usercommands
 
 import (
 	"github.com/volte6/mud/characters"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 )
 
-func Flee(rest string, user *users.UserRecord) (bool, error) {
+func Flee(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.Aggro == nil {
 		user.SendText(`You aren't in combat!`)

--- a/usercommands/follow.go
+++ b/usercommands/follow.go
@@ -7,13 +7,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Follow(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Follow(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -27,7 +21,7 @@ func Follow(rest string, userId int) (bool, error) {
 	}
 
 	playerId, _ := room.FindByName(rest)
-	if playerId == userId {
+	if playerId == user.UserId {
 		playerId = 0
 	}
 
@@ -43,7 +37,7 @@ func Follow(rest string, userId int) (bool, error) {
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> is following you.`, user.Character.Name),
 		)
 
-		followUser.Character.AddFollower(userId)
+		followUser.Character.AddFollower(user.UserId)
 
 	}
 

--- a/usercommands/follow.go
+++ b/usercommands/follow.go
@@ -7,13 +7,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Follow(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Follow(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "" {
 		user.SendText("Follow whom?")

--- a/usercommands/gearup.go
+++ b/usercommands/gearup.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Gearup(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Gearup(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)

--- a/usercommands/gearup.go
+++ b/usercommands/gearup.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Gearup(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Gearup(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	wornItems := map[items.ItemType]items.Item{}
 	wearNewItems := map[items.ItemType]items.Item{}

--- a/usercommands/get.go
+++ b/usercommands/get.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Get(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Get(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -36,14 +30,14 @@ func Get(rest string, userId int) (bool, error) {
 
 	if args[0] == "all" {
 		if room.Gold > 0 {
-			Get(`gold`, userId)
+			Get(`gold`, user)
 		}
 
 		if len(room.Items) > 0 {
 			iCopies := append([]items.Item{}, room.Items...)
 
 			for _, item := range iCopies {
-				Get(item.Name(), userId)
+				Get(item.Name(), user)
 			}
 		}
 
@@ -107,7 +101,7 @@ func Get(rest string, userId int) (bool, error) {
 				)
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> picks up some <ansi fg="gold">gold</ansi> from the <ansi fg="container">%s</ansi>.`, user.Character.Name, containerName),
-					userId,
+					user.UserId,
 				)
 			}
 
@@ -144,10 +138,10 @@ func Get(rest string, userId int) (bool, error) {
 				)
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> picks up the <ansi fg="itemname">%s</ansi> from the <ansi fg="container">%s</ansi>...`, user.Character.Name, matchItem.DisplayName(), containerName),
-					userId,
+					user.UserId,
 				)
 
-				scripting.TryItemScriptEvent(`onFound`, matchItem, userId)
+				scripting.TryItemScriptEvent(`onFound`, matchItem, user.UserId)
 
 			} else {
 				user.SendText(
@@ -177,7 +171,7 @@ func Get(rest string, userId int) (bool, error) {
 				)
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> picks up some <ansi fg="gold">gold</ansi>.`, user.Character.Name),
-					userId,
+					user.UserId,
 				)
 			}
 
@@ -190,7 +184,7 @@ func Get(rest string, userId int) (bool, error) {
 		// Check if user is specifying an item they stashed
 		if !found && !getFromStash {
 			stashItemMatch, stashFound := room.FindOnFloor(rest, true)
-			if stashFound && stashItemMatch.StashedBy == userId {
+			if stashFound && stashItemMatch.StashedBy == user.UserId {
 				found = true
 				getFromStash = true
 				matchItem = stashItemMatch
@@ -234,7 +228,7 @@ func Get(rest string, userId int) (bool, error) {
 					)
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> digs around in the area and picks something up...`, user.Character.Name),
-						userId,
+						user.UserId,
 					)
 				} else {
 					user.SendText(
@@ -242,10 +236,10 @@ func Get(rest string, userId int) (bool, error) {
 					)
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> picks up the <ansi fg="itemname">%s</ansi>...`, user.Character.Name, matchItem.DisplayName()),
-						userId,
+						user.UserId,
 					)
 				}
-				scripting.TryItemScriptEvent(`onFound`, matchItem, userId)
+				scripting.TryItemScriptEvent(`onFound`, matchItem, user.UserId)
 
 			} else {
 				user.SendText(

--- a/usercommands/get.go
+++ b/usercommands/get.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Get(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Get(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
@@ -30,14 +24,14 @@ func Get(rest string, user *users.UserRecord) (bool, error) {
 
 	if args[0] == "all" {
 		if room.Gold > 0 {
-			Get(`gold`, user)
+			Get(`gold`, user, room)
 		}
 
 		if len(room.Items) > 0 {
 			iCopies := append([]items.Item{}, room.Items...)
 
 			for _, item := range iCopies {
-				Get(item.Name(), user)
+				Get(item.Name(), user, room)
 			}
 		}
 

--- a/usercommands/give.go
+++ b/usercommands/give.go
@@ -15,13 +15,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Give(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Give(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	rest = util.StripPrepositions(rest)
 

--- a/usercommands/give.go
+++ b/usercommands/give.go
@@ -15,13 +15,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Give(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Give(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -109,7 +103,7 @@ func Give(rest string, userId int) (bool, error) {
 				targetUser.UserId)
 
 			// Trigger onLost event
-			scripting.TryItemScriptEvent(`onLost`, giveItem, userId)
+			scripting.TryItemScriptEvent(`onLost`, giveItem, user.UserId)
 
 			scripting.TryItemScriptEvent(`onFound`, giveItem, targetUser.UserId)
 
@@ -170,7 +164,7 @@ func Give(rest string, userId int) (bool, error) {
 					)
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> gave some gold to <ansi fg="mobname">%s</ansi>.`, user.Character.Name, m.Character.Name),
-						userId,
+						user.UserId,
 					)
 				} else {
 
@@ -182,15 +176,15 @@ func Give(rest string, userId int) (bool, error) {
 					)
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> gave their <ansi fg="item">%s</ansi> to <ansi fg="mobname">%s</ansi>.`, user.Character.Name, giveItem.DisplayName(), m.Character.Name),
-						userId,
+						user.UserId,
 					)
 
 					// Trigger onLost event
-					scripting.TryItemScriptEvent(`onLost`, giveItem, userId)
+					scripting.TryItemScriptEvent(`onLost`, giveItem, user.UserId)
 
 				}
 
-				if handled, err := scripting.TryMobScriptEvent(`onGive`, m.InstanceId, userId, `user`, map[string]any{`gold`: giveGoldAmount, `item`: giveItem}); err == nil {
+				if handled, err := scripting.TryMobScriptEvent(`onGive`, m.InstanceId, user.UserId, `user`, map[string]any{`gold`: giveGoldAmount, `item`: giveItem}); err == nil {
 					if handled {
 						return true, nil
 					}

--- a/usercommands/go.go
+++ b/usercommands/go.go
@@ -14,7 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Go(rest string, user *users.UserRecord) (bool, error) {
+func Go(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.Aggro != nil {
 		user.SendText("You can't do that! You are in combat!")
@@ -28,12 +28,6 @@ func Go(rest string, user *users.UserRecord) (bool, error) {
 	}
 
 	isSneaking := user.Character.HasBuffFlag(buffs.Hidden)
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
 
 	handled := false
 
@@ -295,7 +289,7 @@ func Go(rest string, user *users.UserRecord) (bool, error) {
 			}
 
 			handled = true
-			Look(`secretly`, user)
+			Look(`secretly`, user, room)
 
 			scripting.TryRoomScriptEvent(`onEnter`, user.UserId, destRoom.RoomId)
 		}

--- a/usercommands/go.go
+++ b/usercommands/go.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Go(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Go(rest string, user *users.UserRecord) (bool, error) {
 
 	if user.Character.Aggro != nil {
 		user.SendText("You can't do that! You are in combat!")
@@ -93,7 +87,7 @@ func Go(rest string, userId int) (bool, error) {
 				user.SendText(`You know this lock well, you quickly pick it.`)
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> quickly picks the lock on the <ansi fg="exit">%s</ansi> exit.`, user.Character.Name, exitName),
-					userId)
+					user.UserId)
 
 				exitInfo.Lock.SetUnlocked()
 				room.Exits[exitName] = exitInfo
@@ -102,7 +96,7 @@ func Go(rest string, userId int) (bool, error) {
 				user.SendText(fmt.Sprintf(`You use the key on your key ring to unlock the <ansi fg="exit">%s</ansi> exit.`, exitName))
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to unlock the <ansi fg="exit">%s</ansi> exit.`, user.Character.Name, exitName),
-					userId)
+					user.UserId)
 
 				exitInfo.Lock.SetUnlocked()
 				room.Exits[exitName] = exitInfo
@@ -116,7 +110,7 @@ func Go(rest string, userId int) (bool, error) {
 					user.SendText(fmt.Sprintf(`You use your <ansi fg="item">%s</ansi> to unlock the <ansi fg="exit">%s</ansi> exit, and add it to your key ring for the future.`, itmSpec.Name, exitName))
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to unlock the <ansi fg="exit">%s</ansi> exit.`, user.Character.Name, exitName),
-						userId)
+						user.UserId)
 
 					// Key entries look like:
 					// "key-<roomid>-<exitname>": "<itemid>"
@@ -186,23 +180,23 @@ func Go(rest string, userId int) (bool, error) {
 					fmt.Sprintf(string(c.ExitRoomMessageWrapper),
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> leaves towards the <ansi fg="exit">%s</ansi> exit.`, user.Character.Name, exitName),
 					),
-					userId)
+					user.UserId)
 				// Tell the new room they have arrived
 				destRoom.SendText(
 					fmt.Sprintf(string(c.EnterRoomMessageWrapper),
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> enters from %s.`, user.Character.Name, enterFromExit),
 					),
-					userId)
+					user.UserId)
 
 				destRoom.SendTextToExits(`You hear someone moving around.`, true, room.GetPlayers(rooms.FindAll)...)
 			}
 
-			if currentParty := parties.Get(userId); currentParty != nil {
+			if currentParty := parties.Get(user.UserId); currentParty != nil {
 
-				if currentParty.IsLeader(userId) {
+				if currentParty.IsLeader(user.UserId) {
 
 					for _, partyMemberId := range currentParty.UserIds {
-						if partyMemberId == userId {
+						if partyMemberId == user.UserId {
 							continue
 						}
 						if partyUser := users.GetByUserId(partyMemberId); partyUser != nil {
@@ -221,7 +215,7 @@ func Go(rest string, userId int) (bool, error) {
 				if mob == nil {
 					continue
 				}
-				if mob.Character.IsCharmed(userId) { // Charmed mobs follow
+				if mob.Character.IsCharmed(user.UserId) { // Charmed mobs follow
 
 					mob.Command(rest)
 
@@ -301,7 +295,7 @@ func Go(rest string, userId int) (bool, error) {
 			}
 
 			handled = true
-			Look(`secretly`, userId)
+			Look(`secretly`, user)
 
 			scripting.TryRoomScriptEvent(`onEnter`, user.UserId, destRoom.RoomId)
 		}
@@ -320,7 +314,7 @@ func Go(rest string, userId int) (bool, error) {
 					fmt.Sprintf(string(c.ExitRoomMessageWrapper),
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> is bumping into walls.`, user.Character.Name),
 					),
-					userId)
+					user.UserId)
 			}
 			handled = true
 		}

--- a/usercommands/help.go
+++ b/usercommands/help.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Help(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Help(rest string, user *users.UserRecord) (bool, error) {
 
 	var helpTxt string
 	var err error = nil

--- a/usercommands/help.go
+++ b/usercommands/help.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/volte6/mud/keywords"
 	"github.com/volte6/mud/races"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/spells"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Help(rest string, user *users.UserRecord) (bool, error) {
+func Help(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	var helpTxt string
 	var err error = nil

--- a/usercommands/inventory.go
+++ b/usercommands/inventory.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Inventory(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Inventory(rest string, user *users.UserRecord) (bool, error) {
 
 	itemNames := []string{}
 	itemNamesFormatted := []string{}

--- a/usercommands/inventory.go
+++ b/usercommands/inventory.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/volte6/mud/items"
 	"github.com/volte6/mud/races"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Inventory(rest string, user *users.UserRecord) (bool, error) {
+func Inventory(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	itemNames := []string{}
 	itemNamesFormatted := []string{}

--- a/usercommands/jobs.go
+++ b/usercommands/jobs.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Jobs(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Jobs(rest string, user *users.UserRecord) (bool, error) {
 
 	type JobDisplay struct {
 		Name       string

--- a/usercommands/jobs.go
+++ b/usercommands/jobs.go
@@ -6,13 +6,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/skills"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Jobs(rest string, user *users.UserRecord) (bool, error) {
+func Jobs(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	type JobDisplay struct {
 		Name       string

--- a/usercommands/keyring.go
+++ b/usercommands/keyring.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func KeyRing(rest string, user *users.UserRecord) (bool, error) {
+func KeyRing(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	headers := []string{`Type`, `Location`, `Where`, `Sequence`}
 	allFormatting := [][]string{}

--- a/usercommands/keyring.go
+++ b/usercommands/keyring.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func KeyRing(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func KeyRing(rest string, user *users.UserRecord) (bool, error) {
 
 	headers := []string{`Type`, `Location`, `Where`, `Sequence`}
 	allFormatting := [][]string{}

--- a/usercommands/killstats.go
+++ b/usercommands/killstats.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Killstats(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Killstats(rest string, user *users.UserRecord) (bool, error) {
 
 	otherSuggestions := []string{}
 

--- a/usercommands/killstats.go
+++ b/usercommands/killstats.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/volte6/mud/mobs"
 	"github.com/volte6/mud/races"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Killstats(rest string, user *users.UserRecord) (bool, error) {
+func Killstats(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	otherSuggestions := []string{}
 

--- a/usercommands/list.go
+++ b/usercommands/list.go
@@ -18,13 +18,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func List(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	listedSomething := false
 

--- a/usercommands/list.go
+++ b/usercommands/list.go
@@ -18,13 +18,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func List(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func List(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -199,7 +193,7 @@ func List(rest string, userId int) (bool, error) {
 
 	for _, uid := range room.GetPlayers(rooms.FindMerchant) {
 
-		if uid == userId {
+		if uid == user.UserId {
 			continue
 		}
 

--- a/usercommands/lock.go
+++ b/usercommands/lock.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Lock(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Lock(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -57,7 +51,7 @@ func Lock(rest string, userId int) (bool, error) {
 			room.Containers[containerName] = container
 
 			user.SendText(fmt.Sprintf(`You use a key to relock the <ansi fg="container">%s</ansi>.`, containerName))
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to relock the <ansi fg="container">%s</ansi>.`, user.Character.Name, containerName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to relock the <ansi fg="container">%s</ansi>.`, user.Character.Name, containerName), user.UserId)
 		} else if hasBackpackKey {
 
 			itmSpec := backpackKeyItm.GetSpec()
@@ -73,7 +67,7 @@ func Lock(rest string, userId int) (bool, error) {
 			user.SendText(fmt.Sprintf(`You use your <ansi fg="item">%s</ansi> to lock the <ansi fg="container">%s</ansi>, and add it to your key ring for the future.`, itmSpec.Name, containerName))
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to lock the <ansi fg="container">%s</ansi>.`, user.Character.Name, containerName),
-				userId)
+				user.UserId)
 		} else {
 			user.SendText(`You do not have the key for that.`)
 		}
@@ -103,7 +97,7 @@ func Lock(rest string, userId int) (bool, error) {
 			room.Exits[exitName] = exitInfo
 
 			user.SendText(fmt.Sprintf(`You use a key to relock the <ansi fg="exit">%s</ansi> lock.`, exitName))
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to relock the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to relock the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), user.UserId)
 		} else if hasBackpackKey {
 
 			itmSpec := backpackKeyItm.GetSpec()
@@ -119,7 +113,7 @@ func Lock(rest string, userId int) (bool, error) {
 			user.SendText(fmt.Sprintf(`You use your <ansi fg="item">%s</ansi> to lock the <ansi fg="exit">%s</ansi> exit, and add it to your key ring for the future.`, itmSpec.Name, exitName))
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to lock the <ansi fg="exit">%s</ansi> exit.`, user.Character.Name, exitName),
-				userId)
+				user.UserId)
 		} else {
 			user.SendText(`You do not have the key for that.`)
 		}

--- a/usercommands/lock.go
+++ b/usercommands/lock.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Lock(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Lock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/usercommands/look.go
+++ b/usercommands/look.go
@@ -13,18 +13,12 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Look(rest string, user *users.UserRecord) (bool, error) {
+func Look(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	secretLook := false
 	if strings.HasPrefix(rest, "secretly") {
 		secretLook = true
 		rest = strings.TrimSpace(strings.TrimPrefix(rest, "secretly"))
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	// 0 = none. 1 = can see this room. 2 = can see this room and all exits

--- a/usercommands/macros.go
+++ b/usercommands/macros.go
@@ -6,13 +6,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Macros(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Macros(rest string, user *users.UserRecord) (bool, error) {
 
 	if len(user.Macros) == 0 {
 		user.SendText("You have no macros set.")

--- a/usercommands/macros.go
+++ b/usercommands/macros.go
@@ -3,10 +3,11 @@ package usercommands
 import (
 	"fmt"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 )
 
-func Macros(rest string, user *users.UserRecord) (bool, error) {
+func Macros(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if len(user.Macros) == 0 {
 		user.SendText("You have no macros set.")

--- a/usercommands/motd.go
+++ b/usercommands/motd.go
@@ -1,19 +1,11 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/configs"
 	"github.com/volte6/mud/users"
 )
 
-func Motd(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Motd(rest string, user *users.UserRecord) (bool, error) {
 
 	user.SendText(string(configs.GetConfig().Motd))
 

--- a/usercommands/motd.go
+++ b/usercommands/motd.go
@@ -2,10 +2,11 @@ package usercommands
 
 import (
 	"github.com/volte6/mud/configs"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 )
 
-func Motd(rest string, user *users.UserRecord) (bool, error) {
+func Motd(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	user.SendText(string(configs.GetConfig().Motd))
 

--- a/usercommands/offer.go
+++ b/usercommands/offer.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Offer(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Offer(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)

--- a/usercommands/offer.go
+++ b/usercommands/offer.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Offer(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Offer(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	item, found := user.Character.FindInBackpack(rest)
 	if !found {

--- a/usercommands/online.go
+++ b/usercommands/online.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Online(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Online(rest string, user *users.UserRecord) (bool, error) {
 
 	headers := []string{`Name`, `Level`, `Alignment`, `Profession`, `Online`, `Role`}
 

--- a/usercommands/online.go
+++ b/usercommands/online.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/skills"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Online(rest string, user *users.UserRecord) (bool, error) {
+func Online(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	headers := []string{`Name`, `Level`, `Alignment`, `Profession`, `Online`, `Role`}
 

--- a/usercommands/party.go
+++ b/usercommands/party.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Party(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Party(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/usercommands/party.go
+++ b/usercommands/party.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Party(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Party(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -36,15 +30,15 @@ func Party(rest string, userId int) (bool, error) {
 		rest = strings.TrimSpace(rest)
 	}
 
-	currentParty := parties.Get(userId)
+	currentParty := parties.Get(user.UserId)
 
 	if partyCommand == `create` || partyCommand == `new` || partyCommand == `start` {
 
 		// check if they are already part of a party
 		if currentParty != nil {
-			if currentParty.Invited(userId) {
+			if currentParty.Invited(user.UserId) {
 				user.SendText(`You already have a pending party invite. Try <ansi fg="command">party accept/decline</ansi> first`)
-			} else if currentParty.IsLeader(userId) {
+			} else if currentParty.IsLeader(user.UserId) {
 				user.SendText(`You already own a party Type <ansi fg="command">party list</ansi> for more info.`)
 			} else {
 				user.SendText(`You are already party of a party.`)
@@ -52,7 +46,7 @@ func Party(rest string, userId int) (bool, error) {
 			return true, nil
 		}
 
-		if currentParty = parties.New(userId); currentParty != nil {
+		if currentParty = parties.New(user.UserId); currentParty != nil {
 			user.SendText(`You started a new party!`)
 		} else {
 			user.SendText(`Something went wrong.`)
@@ -75,10 +69,10 @@ func Party(rest string, userId int) (bool, error) {
 
 		// Not in a party? Create one.
 		if currentParty == nil {
-			currentParty = parties.New(userId)
+			currentParty = parties.New(user.UserId)
 		}
 
-		if !currentParty.IsLeader(userId) {
+		if !currentParty.IsLeader(user.UserId) {
 			user.SendText(`You are not the leader of your party.`)
 			return true, nil
 		}
@@ -118,11 +112,11 @@ func Party(rest string, userId int) (bool, error) {
 
 	if partyCommand == `accept` || partyCommand == `join` {
 
-		if currentParty.AcceptInvite(userId) {
+		if currentParty.AcceptInvite(user.UserId) {
 
 			user.SendText(`You joined the party!`)
 			for _, uid := range currentParty.UserIds {
-				if uid == userId {
+				if uid == user.UserId {
 					continue
 				}
 				if u := users.GetByUserId(uid); u != nil {
@@ -138,7 +132,7 @@ func Party(rest string, userId int) (bool, error) {
 
 	if partyCommand == `decline` {
 
-		if currentParty.DeclineInvite(userId) {
+		if currentParty.DeclineInvite(user.UserId) {
 
 			if u := users.GetByUserId(currentParty.LeaderUserId); u != nil {
 				u.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> declined the invitation.`, user.Character.Name))
@@ -159,7 +153,7 @@ func Party(rest string, userId int) (bool, error) {
 		rows := [][]string{}
 
 		if currentParty != nil {
-			isInvited := currentParty.Invited(userId)
+			isInvited := currentParty.Invited(user.UserId)
 			leaderId := currentParty.LeaderUserId
 
 			charmedMobInstanceIds := []int{}
@@ -271,7 +265,7 @@ func Party(rest string, userId int) (bool, error) {
 		}
 	}
 
-	if currentParty.Invited(userId) {
+	if currentParty.Invited(user.UserId) {
 		user.SendText(`You haven't accepted an invitation to the party.`)
 		return true, nil
 	}
@@ -290,7 +284,7 @@ func Party(rest string, userId int) (bool, error) {
 			return true, nil
 		}
 
-		wasOnBefore := currentParty.SetAutoAttack(userId, autoAttackOn)
+		wasOnBefore := currentParty.SetAutoAttack(user.UserId, autoAttackOn)
 
 		if autoAttackOn {
 			if wasOnBefore {
@@ -309,7 +303,7 @@ func Party(rest string, userId int) (bool, error) {
 
 	if partyCommand == `leave` || partyCommand == `quit` {
 
-		if currentParty.IsLeader(userId) {
+		if currentParty.IsLeader(user.UserId) {
 
 			if len(currentParty.UserIds) <= 1 {
 				user.SendText(`You disbanded the party.`)
@@ -321,7 +315,7 @@ func Party(rest string, userId int) (bool, error) {
 
 			// promote someone else to leader
 			for _, uid := range currentParty.UserIds {
-				if uid == userId {
+				if uid == user.UserId {
 					continue
 				}
 
@@ -350,12 +344,12 @@ func Party(rest string, userId int) (bool, error) {
 			}
 		}
 
-		currentParty.Leave(userId)
+		currentParty.Leave(user.UserId)
 
 		user.SendText(`You left the party.`)
 
 		for _, uid := range currentParty.UserIds {
-			if uid == userId {
+			if uid == user.UserId {
 				continue
 			}
 			if u := users.GetByUserId(uid); u != nil {
@@ -367,13 +361,13 @@ func Party(rest string, userId int) (bool, error) {
 
 	if partyCommand == `disband` || partyCommand == `stop` {
 
-		if !currentParty.IsLeader(userId) {
+		if !currentParty.IsLeader(user.UserId) {
 			user.SendText(`You are not the leader of your party.`)
 			return true, nil
 		}
 
 		for _, uid := range currentParty.UserIds {
-			if uid == userId {
+			if uid == user.UserId {
 				continue
 			}
 			if u := users.GetByUserId(uid); u != nil {
@@ -395,7 +389,7 @@ func Party(rest string, userId int) (bool, error) {
 
 	if partyCommand == `kick` {
 
-		if !currentParty.IsLeader(userId) {
+		if !currentParty.IsLeader(user.UserId) {
 			user.SendText(`You are not the leader of your party.`)
 			return true, nil
 		}
@@ -438,7 +432,7 @@ func Party(rest string, userId int) (bool, error) {
 
 	if partyCommand == `promote` {
 
-		if !currentParty.IsLeader(userId) {
+		if !currentParty.IsLeader(user.UserId) {
 			user.SendText(`You are not the leader of your party.`)
 			return true, nil
 		}
@@ -490,7 +484,7 @@ func Party(rest string, userId int) (bool, error) {
 		}
 
 		for _, uId := range currentParty.GetMembers() {
-			if uId == userId {
+			if uId == user.UserId {
 				continue
 			}
 			if u := users.GetByUserId(uId); u != nil {

--- a/usercommands/picklock.go
+++ b/usercommands/picklock.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Picklock(rest string, user *users.UserRecord) (bool, error) {
+func Picklock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	lockpickItm := items.Item{}
 	for _, itm := range user.Character.GetAllBackpackItems() {
@@ -25,12 +25,6 @@ func Picklock(rest string, user *users.UserRecord) (bool, error) {
 	if lockpickItm.ItemId < 1 {
 		user.SendText(`You need <ansi fg="item">lockpicks</ansi> to pick a lock.`)
 		return true, nil
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))

--- a/usercommands/picklock.go
+++ b/usercommands/picklock.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Picklock(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Picklock(rest string, user *users.UserRecord) (bool, error) {
 
 	lockpickItm := items.Item{}
 	for _, itm := range user.Character.GetAllBackpackItems() {
@@ -116,14 +110,14 @@ func Picklock(rest string, userId int) (bool, error) {
 
 		if containerName != `` {
 
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="container">%s</ansi> lock`, user.Character.Name, containerName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="container">%s</ansi> lock`, user.Character.Name, containerName), user.UserId)
 
 			container := room.Containers[containerName]
 			container.Lock.SetUnlocked()
 			room.Containers[containerName] = container
 		} else {
 
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), user.UserId)
 
 			exitInfo := room.Exits[exitName]
 			exitInfo.Lock.SetUnlocked()
@@ -201,14 +195,14 @@ func Picklock(rest string, userId int) (bool, error) {
 
 		if containerName != `` {
 
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="container">%s</ansi> lock`, user.Character.Name, containerName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="container">%s</ansi> lock`, user.Character.Name, containerName), user.UserId)
 
 			container := room.Containers[containerName]
 			container.Lock.SetUnlocked()
 			room.Containers[containerName] = container
 		} else {
 
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> picks the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), user.UserId)
 
 			exitInfo := room.Exits[exitName]
 			exitInfo.Lock.SetUnlocked()
@@ -221,9 +215,9 @@ func Picklock(rest string, userId int) (bool, error) {
 
 	} else {
 		if containerName != `` {
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> tries to pick the <ansi fg="container">%s</ansi> lock`, user.Character.Name, containerName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> tries to pick the <ansi fg="container">%s</ansi> lock`, user.Character.Name, containerName), user.UserId)
 		} else {
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> tries to pick the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> tries to pick the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), user.UserId)
 		}
 	}
 

--- a/usercommands/print.go
+++ b/usercommands/print.go
@@ -2,12 +2,13 @@ package usercommands
 
 import (
 	"github.com/volte6/mud/events"
+	"github.com/volte6/mud/users"
 )
 
-func Print(rest string, userId int) (bool, error) {
+func Print(rest string, user *users.UserRecord) (bool, error) {
 
 	events.AddToQueue(events.Message{
-		UserId: userId,
+		UserId: user.UserId,
 		Text:   rest,
 	})
 

--- a/usercommands/print.go
+++ b/usercommands/print.go
@@ -2,10 +2,11 @@ package usercommands
 
 import (
 	"github.com/volte6/mud/events"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 )
 
-func Print(rest string, user *users.UserRecord) (bool, error) {
+func Print(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	events.AddToQueue(events.Message{
 		UserId: user.UserId,

--- a/usercommands/quests.go
+++ b/usercommands/quests.go
@@ -6,12 +6,13 @@ import (
 	"sort"
 
 	"github.com/volte6/mud/quests"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Quests(rest string, user *users.UserRecord) (bool, error) {
+func Quests(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	type QuestRecord struct {
 		Id          int

--- a/usercommands/quests.go
+++ b/usercommands/quests.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Quests(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Quests(rest string, user *users.UserRecord) (bool, error) {
 
 	type QuestRecord struct {
 		Id          int

--- a/usercommands/quit.go
+++ b/usercommands/quit.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Quit(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Quit(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -28,7 +22,7 @@ func Quit(rest string, userId int) (bool, error) {
 	}
 
 	events.AddToQueue(events.Buff{
-		UserId:        userId,
+		UserId:        user.UserId,
 		MobInstanceId: 0,
 		BuffId:        0,
 	})

--- a/usercommands/quit.go
+++ b/usercommands/quit.go
@@ -1,20 +1,12 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/events"
 	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 )
 
-func Quit(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Quit(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.Aggro != nil {
 		user.SendText("You're too busy to quit right now!")

--- a/usercommands/read.go
+++ b/usercommands/read.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Read(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Read(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -53,7 +47,7 @@ func Read(rest string, userId int) (bool, error) {
 		if !isSneaking {
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> looks at their <ansi fg="item">%s</ansi>...`, user.Character.Name, foundItemName),
-				userId,
+				user.UserId,
 			)
 		}
 

--- a/usercommands/read.go
+++ b/usercommands/read.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Read(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Read(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 

--- a/usercommands/remove.go
+++ b/usercommands/remove.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Remove(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Remove(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -25,7 +19,7 @@ func Remove(rest string, userId int) (bool, error) {
 
 	if rest == "all" {
 		for _, item := range user.Character.Equipment.GetAllItems() {
-			Remove(item.Name(), userId)
+			Remove(item.Name(), user)
 		}
 		return true, nil
 	}
@@ -59,7 +53,7 @@ func Remove(rest string, userId int) (bool, error) {
 			)
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> removes their <ansi fg="item">%s</ansi> and stores it away.`, user.Character.Name, matchItem.DisplayName()),
-				userId,
+				user.UserId,
 			)
 
 			user.Character.StoreItem(matchItem)

--- a/usercommands/remove.go
+++ b/usercommands/remove.go
@@ -9,17 +9,11 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Remove(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Remove(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if rest == "all" {
 		for _, item := range user.Character.Equipment.GetAllItems() {
-			Remove(item.Name(), user)
+			Remove(item.Name(), user, room)
 		}
 		return true, nil
 	}

--- a/usercommands/save.go
+++ b/usercommands/save.go
@@ -1,10 +1,11 @@
 package usercommands
 
 import (
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 )
 
-func Save(rest string, user *users.UserRecord) (bool, error) {
+func Save(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	user.SendText("Saving...")
 	users.SaveUser(*user)

--- a/usercommands/save.go
+++ b/usercommands/save.go
@@ -1,17 +1,10 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/users"
 )
 
-func Save(rest string, userId int) (bool, error) {
-
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Save(rest string, user *users.UserRecord) (bool, error) {
 
 	user.SendText("Saving...")
 	users.SaveUser(*user)

--- a/usercommands/say.go
+++ b/usercommands/say.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Say(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Say(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	isSneaking := user.Character.HasBuffFlag(buffs.Hidden)
 	isDrunk := user.Character.HasBuffFlag(buffs.Drunk)

--- a/usercommands/say.go
+++ b/usercommands/say.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Say(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Say(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -32,9 +26,9 @@ func Say(rest string, userId int) (bool, error) {
 		rest = drunkify(rest)
 	}
 	if isSneaking {
-		room.SendText(fmt.Sprintf(`someone says, "<ansi fg="saytext">%s</ansi>"`, rest), userId)
+		room.SendText(fmt.Sprintf(`someone says, "<ansi fg="saytext">%s</ansi>"`, rest), user.UserId)
 	} else {
-		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> says, "<ansi fg="saytext">%s</ansi>"`, user.Character.Name, rest), userId)
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> says, "<ansi fg="saytext">%s</ansi>"`, user.Character.Name, rest), user.UserId)
 	}
 
 	user.SendText(fmt.Sprintf(`You say, "<ansi fg="saytext">%s</ansi>"`, rest))

--- a/usercommands/sell.go
+++ b/usercommands/sell.go
@@ -10,14 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Sell(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Sell(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -87,11 +80,11 @@ func Sell(rest string, userId int) (bool, error) {
 		)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> sells a <ansi fg="itemname">%s</ansi>.`, user.Character.Name, item.DisplayName()),
-			userId,
+			user.UserId,
 		)
 
 		// Trigger lost event
-		scripting.TryItemScriptEvent(`onLost`, item, userId)
+		scripting.TryItemScriptEvent(`onLost`, item, user.UserId)
 
 		break
 	}

--- a/usercommands/sell.go
+++ b/usercommands/sell.go
@@ -10,14 +10,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Sell(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Sell(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	item, found := user.Character.FindInBackpack(rest)
 

--- a/usercommands/set.go
+++ b/usercommands/set.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Set(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Set(rest string, user *users.UserRecord) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/usercommands/set.go
+++ b/usercommands/set.go
@@ -5,11 +5,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Set(rest string, user *users.UserRecord) (bool, error) {
+func Set(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/usercommands/share.go
+++ b/usercommands/share.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Share(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Share(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	party := parties.Get(user.UserId)
 	if party == nil {

--- a/usercommands/share.go
+++ b/usercommands/share.go
@@ -12,13 +12,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Share(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Share(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -26,7 +20,7 @@ func Share(rest string, userId int) (bool, error) {
 		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
-	party := parties.Get(userId)
+	party := parties.Get(user.UserId)
 	if party == nil {
 		user.SendText("You can only share in a party.")
 		return true, nil
@@ -54,9 +48,9 @@ func Share(rest string, userId int) (bool, error) {
 			return true, nil
 		}
 
-		partyMembersInRoom := []int{userId} // make sure party leader gets first share
+		partyMembersInRoom := []int{user.UserId} // make sure party leader gets first share
 		for _, uid := range room.GetPlayers(rooms.FindAll) {
-			if uid == userId {
+			if uid == user.UserId {
 				continue
 			}
 			if party.IsMember(uid) {

--- a/usercommands/shoot.go
+++ b/usercommands/shoot.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Shoot(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Shoot(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -90,7 +84,7 @@ func Shoot(rest string, userId int) (bool, error) {
 
 		if m != nil {
 
-			if m.Character.IsCharmed(userId) {
+			if m.Character.IsCharmed(user.UserId) {
 				user.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> is your friend!`, m.Character.Name))
 				return true, nil
 			}
@@ -104,7 +98,7 @@ func Shoot(rest string, userId int) (bool, error) {
 			if !isSneaking {
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to shoot at <ansi fg="mobname">%s</ansi> through the <ansi fg="exit">%s</ansi> exit.`, user.Character.Name, m.Character.Name, exitName),
-					userId,
+					user.UserId,
 				)
 			}
 
@@ -133,7 +127,7 @@ func Shoot(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to shoot at <ansi fg="username">%s</ansi> through the <ansi fg="exit">%s</ansi> exit.`, user.Character.Name, p.Character.Name, exitName),
-					userId,
+					user.UserId,
 				)
 
 			}

--- a/usercommands/shoot.go
+++ b/usercommands/shoot.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Shoot(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Shoot(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.Equipment.Weapon.GetSpec().Subtype != items.Shooting {
 		user.SendText(`You don't have a shooting weapon.`)

--- a/usercommands/shout.go
+++ b/usercommands/shout.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Shout(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Shout(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -34,15 +28,15 @@ func Shout(rest string, userId int) (bool, error) {
 	}
 
 	if isSneaking {
-		room.SendText(fmt.Sprintf(`someone shouts, "<ansi fg="yellow">%s</ansi>"`, rest), userId)
+		room.SendText(fmt.Sprintf(`someone shouts, "<ansi fg="yellow">%s</ansi>"`, rest), user.UserId)
 	} else {
-		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> shouts, "<ansi fg="yellow">%s</ansi>"`, user.Character.Name, rest), userId)
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> shouts, "<ansi fg="yellow">%s</ansi>"`, user.Character.Name, rest), user.UserId)
 	}
 
 	for _, roomInfo := range room.Exits {
 		if otherRoom := rooms.LoadRoom(roomInfo.RoomId); otherRoom != nil {
 			if sourceExit := otherRoom.FindExitTo(room.RoomId); sourceExit != `` {
-				otherRoom.SendText(fmt.Sprintf(`Someone shouts from the <ansi fg="exit">%s</ansi> direction, "<ansi fg="yellow">%s</ansi>"`, sourceExit, rest), userId)
+				otherRoom.SendText(fmt.Sprintf(`Someone shouts from the <ansi fg="exit">%s</ansi> direction, "<ansi fg="yellow">%s</ansi>"`, sourceExit, rest), user.UserId)
 			}
 		}
 	}

--- a/usercommands/shout.go
+++ b/usercommands/shout.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Shout(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Shout(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	isSneaking := user.Character.HasBuffFlag(buffs.Hidden)
 	isDrunk := user.Character.HasBuffFlag(buffs.Drunk)

--- a/usercommands/show.go
+++ b/usercommands/show.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Show(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Show(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	rest = util.StripPrepositions(rest)
 

--- a/usercommands/show.go
+++ b/usercommands/show.go
@@ -13,13 +13,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Show(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Show(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -80,7 +74,7 @@ func Show(rest string, userId int) (bool, error) {
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> shows their <ansi fg="item">%s</ansi> to <ansi fg="username">%s</ansi>.`, user.Character.Name, showItem.DisplayName(), targetUser.Character.Name),
 				targetUser.UserId,
-				userId)
+				user.UserId)
 
 		} else {
 			user.SendText("Something went wrong.")
@@ -108,11 +102,11 @@ func Show(rest string, userId int) (bool, error) {
 				)
 
 				// Do trigger of onShow
-				scripting.TryMobScriptEvent(`onShow`, targetMob.InstanceId, userId, `user`, map[string]any{`gold`: 0, `item`: showItem})
+				scripting.TryMobScriptEvent(`onShow`, targetMob.InstanceId, user.UserId, `user`, map[string]any{`gold`: 0, `item`: showItem})
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> shows their <ansi fg="item">%s</ansi> to <ansi fg="mobname">%s</ansi>.`, user.Character.Name, showItem.DisplayName(), targetMob.Character.Name),
-					userId,
+					user.UserId,
 				)
 
 			} else {

--- a/usercommands/skill.brawling.disarm.go
+++ b/usercommands/skill.brawling.disarm.go
@@ -14,7 +14,7 @@ import (
 Brawling Skill
 Level 4 - Attempt to disarm an opponent.
 */
-func Disarm(rest string, user *users.UserRecord) (bool, error) {
+func Disarm(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 
@@ -26,12 +26,6 @@ func Disarm(rest string, user *users.UserRecord) (bool, error) {
 	if user.Character.Aggro == nil {
 		user.SendText("Disarm is only used while in combat!")
 		return true, nil
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	attackMobInstanceId := user.Character.Aggro.MobInstanceId

--- a/usercommands/skill.brawling.disarm.go
+++ b/usercommands/skill.brawling.disarm.go
@@ -14,13 +14,7 @@ import (
 Brawling Skill
 Level 4 - Attempt to disarm an opponent.
 */
-func Disarm(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Disarm(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 
@@ -78,7 +72,7 @@ func Disarm(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> disarms <ansi fg="mobname">%s</ansi>!`, user.Character.Name, m.Character.Name),
-					userId,
+					user.UserId,
 				)
 
 				removedItem := m.Character.Equipment.Weapon
@@ -92,7 +86,7 @@ func Disarm(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> tries to disarm <ansi fg="mobname">%s</ansi> and fails!`, user.Character.Name, m.Character.Name),
-					userId,
+					user.UserId,
 				)
 
 			}
@@ -126,7 +120,7 @@ func Disarm(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> disarms <ansi fg="username">%s</ansi>!`, user.Character.Name, u.Character.Name),
-					userId,
+					user.UserId,
 					attackPlayerId,
 				)
 
@@ -147,7 +141,7 @@ func Disarm(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> tries to disarm <ansi fg="username">%s</ansi> and misses!`, user.Character.Name, u.Character.Name),
-					userId,
+					user.UserId,
 					attackPlayerId,
 				)
 

--- a/usercommands/skill.brawling.recover.go
+++ b/usercommands/skill.brawling.recover.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/volte6/mud/events"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/skills"
 	"github.com/volte6/mud/users"
 )
@@ -12,7 +13,7 @@ import (
 Brawling Skill
 Level 1 - Enter a state of rest where health is recovered more quickly
 */
-func Recover(rest string, user *users.UserRecord) (bool, error) {
+func Recover(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 

--- a/usercommands/skill.brawling.recover.go
+++ b/usercommands/skill.brawling.recover.go
@@ -12,13 +12,7 @@ import (
 Brawling Skill
 Level 1 - Enter a state of rest where health is recovered more quickly
 */
-func Recover(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Recover(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 
@@ -47,7 +41,7 @@ func Recover(rest string, userId int) (bool, error) {
 	}
 
 	events.AddToQueue(events.Buff{
-		UserId:        userId,
+		UserId:        user.UserId,
 		MobInstanceId: 0,
 		BuffId:        applyBuffId,
 	})

--- a/usercommands/skill.brawling.tackle.go
+++ b/usercommands/skill.brawling.tackle.go
@@ -15,13 +15,7 @@ import (
 Brawling Skill
 Level 3 - Attempt to tackle an opponent, making them miss a round.
 */
-func Tackle(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Tackle(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 
@@ -72,7 +66,7 @@ func Tackle(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> lunges and tackles <ansi fg="mobname">%s</ansi>!`, user.Character.Name, m.Character.Name),
-					userId,
+					user.UserId,
 				)
 
 				events.AddToQueue(events.Buff{
@@ -88,7 +82,7 @@ func Tackle(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> tries to tackle <ansi fg="mobname">%s</ansi> and misses!`, user.Character.Name, m.Character.Name),
-					userId,
+					user.UserId,
 				)
 
 			}
@@ -122,7 +116,7 @@ func Tackle(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> lunges and tackles <ansi fg="username">%s</ansi>!`, user.Character.Name, u.Character.Name),
-					userId,
+					user.UserId,
 					attackPlayerId,
 				)
 
@@ -145,7 +139,7 @@ func Tackle(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> lunges to tackle <ansi fg="username">%s</ansi> and misses!`, user.Character.Name, u.Character.Name),
-					userId,
+					user.UserId,
 					attackPlayerId,
 				)
 

--- a/usercommands/skill.brawling.tackle.go
+++ b/usercommands/skill.brawling.tackle.go
@@ -15,7 +15,7 @@ import (
 Brawling Skill
 Level 3 - Attempt to tackle an opponent, making them miss a round.
 */
-func Tackle(rest string, user *users.UserRecord) (bool, error) {
+func Tackle(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 
@@ -27,12 +27,6 @@ func Tackle(rest string, user *users.UserRecord) (bool, error) {
 	if user.Character.Aggro == nil {
 		user.SendText("Tackle is only used while in combat!")
 		return true, nil
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	if !user.Character.TryCooldown(skills.Brawling.String(`tackle`), 5) {

--- a/usercommands/skill.brawling.throw.go
+++ b/usercommands/skill.brawling.throw.go
@@ -21,7 +21,7 @@ import (
 Brawling Skill
 Level 2 - You can throw objects at NPCs or other rooms.
 */
-func Throw(rest string, user *users.UserRecord) (bool, error) {
+func Throw(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 	handled := false
@@ -29,12 +29,6 @@ func Throw(rest string, user *users.UserRecord) (bool, error) {
 	// If they don't have a skill, act like it's not a valid command
 	if skillLevel < 2 {
 		return false, nil
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	args := util.SplitButRespectQuotes(rest)

--- a/usercommands/skill.brawling.throw.go
+++ b/usercommands/skill.brawling.throw.go
@@ -21,13 +21,7 @@ import (
 Brawling Skill
 Level 2 - You can throw objects at NPCs or other rooms.
 */
-func Throw(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Throw(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 	handled := false
@@ -74,7 +68,7 @@ func Throw(rest string, userId int) (bool, error) {
 		if user.Character.RemoveItem(itemMatch) {
 
 			// Trigger onLost event
-			scripting.TryItemScriptEvent(`onLost`, itemMatch, userId)
+			scripting.TryItemScriptEvent(`onLost`, itemMatch, user.UserId)
 
 			// Tell the player they are throwing the item
 			user.SendText(
@@ -84,7 +78,7 @@ func Throw(rest string, userId int) (bool, error) {
 			// Tell the old room they are leaving
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> throws their <ansi fg="itemname">%s</ansi> at <ansi fg="mobname">%s</ansi>.`, user.Character.Name, itemMatch.DisplayName(), targetMob.Character.Name),
-				userId,
+				user.UserId,
 			)
 
 			// If grenades are dropped, they explode and affect everyone in the room!
@@ -128,7 +122,7 @@ func Throw(rest string, userId int) (bool, error) {
 		// Tell the old room they are leaving
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> throws their <ansi fg="itemname">%s</ansi> at <ansi fg="username">%s</ansi>.`, user.Character.Name, itemMatch.DisplayName(), targetUser.Character.Name),
-			userId,
+			user.UserId,
 			targetUser.UserId)
 
 		// If grenades are dropped, they explode and affect everyone in the room!
@@ -195,13 +189,13 @@ func Throw(rest string, userId int) (bool, error) {
 			// Tell the old room they are leaving
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> throws their <ansi fg="item">%s</ansi> through the %s exit.`, user.Character.Name, itemMatch.DisplayName(), exitName),
-				userId,
+				user.UserId,
 			)
 
 			// Tell the new room the item arrived
 			throwToRoom.SendText(
 				fmt.Sprintf(`A <ansi fg="item">%s</ansi> flies through the air from %s and lands on the floor.`, itemMatch.DisplayName(), returnExitName),
-				userId,
+				user.UserId,
 			)
 
 			// If grenades are dropped, they explode and affect everyone in the room!
@@ -270,13 +264,13 @@ func Throw(rest string, userId int) (bool, error) {
 					// Tell the old room they are leaving
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> throws their <ansi fg="item">%s</ansi> through the %s exit.`, user.Character.Name, itemMatch.DisplayName(), tempExit.Title),
-						userId,
+						user.UserId,
 					)
 
 					// Tell the new room the item arrived
 					throwToRoom.SendText(
 						fmt.Sprintf(`A <ansi fg="item">%s</ansi> flies through the air from %s and lands on the floor.`, itemMatch.DisplayName(), returnExitName),
-						userId,
+						user.UserId,
 					)
 
 					// If grenades are dropped, they explode and affect everyone in the room!

--- a/usercommands/skill.cast.go
+++ b/usercommands/skill.cast.go
@@ -23,19 +23,13 @@ Level 2 - Become proficient in a spell at 125% rate
 Level 3 - Become proficient in a spell at 175% rate
 Level 4 - Become proficient in a spell at 250% rate
 */
-func Cast(rest string, user *users.UserRecord) (bool, error) {
+func Cast(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Cast)
 
 	if skillLevel == 0 {
 		user.SendText("You don't know how to cast spells yet.")
 		return true, errors.New(`you don't know how to cast spells yet`)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))

--- a/usercommands/skill.cast.go
+++ b/usercommands/skill.cast.go
@@ -23,13 +23,7 @@ Level 2 - Become proficient in a spell at 125% rate
 Level 3 - Become proficient in a spell at 175% rate
 Level 4 - Become proficient in a spell at 250% rate
 */
-func Cast(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Cast(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Cast)
 
@@ -89,7 +83,7 @@ func Cast(rest string, userId int) (bool, error) {
 		if spellArg == `` {
 
 			// No target specified? Default to self
-			spellAggro.TargetUserIds = append(spellAggro.TargetUserIds, userId)
+			spellAggro.TargetUserIds = append(spellAggro.TargetUserIds, user.UserId)
 
 		} else {
 
@@ -120,7 +114,7 @@ func Cast(rest string, userId int) (bool, error) {
 					for _, mobInstId := range fightingMobs {
 
 						if mob := mobs.GetInstance(mobInstId); mob != nil {
-							if mob.Character.IsAggro(userId, 0) {
+							if mob.Character.IsAggro(user.UserId, 0) {
 								spellAggro.TargetMobInstanceIds = append(spellAggro.TargetMobInstanceIds, mobInstId)
 								break
 							}
@@ -138,7 +132,7 @@ func Cast(rest string, userId int) (bool, error) {
 						for _, fUserId := range fightingPlayers {
 
 							if u := users.GetByUserId(fUserId); u != nil {
-								if u.Character.IsAggro(userId, 0) {
+								if u.Character.IsAggro(user.UserId, 0) {
 									spellAggro.TargetUserIds = append(spellAggro.TargetUserIds, fUserId)
 									break
 								}
@@ -163,14 +157,14 @@ func Cast(rest string, userId int) (bool, error) {
 
 	} else if spellInfo.Type == spells.HelpMulti {
 
-		spellAggro.TargetUserIds = append(spellAggro.TargetUserIds, userId)
+		spellAggro.TargetUserIds = append(spellAggro.TargetUserIds, user.UserId)
 
 		// Targets self and all in party
-		if p := parties.Get(userId); p != nil {
+		if p := parties.Get(user.UserId); p != nil {
 
 			for _, partyUserId := range p.GetMembers() {
 
-				if partyUserId == userId {
+				if partyUserId == user.UserId {
 					continue
 				}
 
@@ -193,7 +187,7 @@ func Cast(rest string, userId int) (bool, error) {
 		fightingMobs := room.GetMobs(rooms.FindFightingPlayer)
 		for _, mobInstId := range fightingMobs {
 			if m := mobs.GetInstance(mobInstId); m != nil {
-				if m.Character.IsAggro(userId, 0) || m.HatesRace(user.Character.Race()) {
+				if m.Character.IsAggro(user.UserId, 0) || m.HatesRace(user.Character.Race()) {
 					spellAggro.TargetMobInstanceIds = append(spellAggro.TargetMobInstanceIds, mobInstId)
 				}
 			}
@@ -202,7 +196,7 @@ func Cast(rest string, userId int) (bool, error) {
 		fightingPlayers := room.GetPlayers(rooms.FindFightingPlayer)
 		for _, uId := range fightingPlayers {
 			if u := users.GetByUserId(uId); u != nil {
-				if u.Character.IsAggro(userId, 0) {
+				if u.Character.IsAggro(user.UserId, 0) {
 					spellAggro.TargetUserIds = append(spellAggro.TargetUserIds, uId)
 				}
 			}
@@ -223,7 +217,7 @@ func Cast(rest string, userId int) (bool, error) {
 	if len(spellAggro.TargetUserIds) > 0 || len(spellAggro.TargetMobInstanceIds) > 0 || len(spellAggro.SpellRest) > 0 {
 
 		continueCasting := true
-		if handled, err := scripting.TrySpellScriptEvent(`onCast`, userId, 0, spellAggro); err == nil {
+		if handled, err := scripting.TrySpellScriptEvent(`onCast`, user.UserId, 0, spellAggro); err == nil {
 			continueCasting = handled
 		}
 

--- a/usercommands/skill.dualwield.go
+++ b/usercommands/skill.dualwield.go
@@ -3,6 +3,7 @@ package usercommands
 import (
 	"errors"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/skills"
 	"github.com/volte6/mud/users"
 )
@@ -14,7 +15,7 @@ Level 2 - Occasionaly you will attack with both weapons in one round.
 Level 3 - You will always attack with both weapons when Dual wielding.
 Level 4 - Dual wielding incurs fewer penalties
 */
-func DualWield(rest string, user *users.UserRecord) (bool, error) {
+func DualWield(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.DualWield)
 
@@ -23,6 +24,6 @@ func DualWield(rest string, user *users.UserRecord) (bool, error) {
 		return true, errors.New(`you haven't learned how to dual wield`)
 	}
 
-	return Help(`dual-wield`, user)
+	return Help(`dual-wield`, user, room)
 
 }

--- a/usercommands/skill.dualwield.go
+++ b/usercommands/skill.dualwield.go
@@ -2,7 +2,6 @@ package usercommands
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/volte6/mud/skills"
 	"github.com/volte6/mud/users"
@@ -15,13 +14,7 @@ Level 2 - Occasionaly you will attack with both weapons in one round.
 Level 3 - You will always attack with both weapons when Dual wielding.
 Level 4 - Dual wielding incurs fewer penalties
 */
-func DualWield(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func DualWield(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.DualWield)
 
@@ -30,6 +23,6 @@ func DualWield(rest string, userId int) (bool, error) {
 		return true, errors.New(`you haven't learned how to dual wield`)
 	}
 
-	return Help(`dual-wield`, userId)
+	return Help(`dual-wield`, user)
 
 }

--- a/usercommands/skill.enchant.go
+++ b/usercommands/skill.enchant.go
@@ -14,12 +14,12 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Uncurse(rest string, user *users.UserRecord) (bool, error) {
-	return Enchant("uncurse "+rest, user)
+func Uncurse(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+	return Enchant("uncurse "+rest, user, room)
 }
 
-func Unenchant(rest string, user *users.UserRecord) (bool, error) {
-	return Enchant("remove "+rest, user)
+func Unenchant(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+	return Enchant("remove "+rest, user, room)
 }
 
 /*
@@ -29,13 +29,7 @@ Level 2 - Enchant equipment with a defensive bonus.
 Level 3 - Add a stat bonus to a weapon or equipment in addition to the above.
 Level 4 - Remove the enchantment or curse from any object.
 */
-func Enchant(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Enchant(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Enchant)
 

--- a/usercommands/skill.enchant.go
+++ b/usercommands/skill.enchant.go
@@ -14,12 +14,12 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Uncurse(rest string, userId int) (bool, error) {
-	return Enchant("uncurse "+rest, userId)
+func Uncurse(rest string, user *users.UserRecord) (bool, error) {
+	return Enchant("uncurse "+rest, user)
 }
 
-func Unenchant(rest string, userId int) (bool, error) {
-	return Enchant("remove "+rest, userId)
+func Unenchant(rest string, user *users.UserRecord) (bool, error) {
+	return Enchant("remove "+rest, user)
 }
 
 /*
@@ -29,13 +29,7 @@ Level 2 - Enchant equipment with a defensive bonus.
 Level 3 - Add a stat bonus to a weapon or equipment in addition to the above.
 Level 4 - Remove the enchantment or curse from any object.
 */
-func Enchant(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Enchant(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -113,7 +107,7 @@ func Enchant(rest string, userId int) (bool, error) {
 
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> holds out their cursed <ansi fg="itemname">%s</ansi> concentrates. An malevolent ethereal whisp seems to float away.`, user.Character.Name, matchItem.DisplayName()),
-				userId,
+				user.UserId,
 			)
 
 			user.SendText(
@@ -132,7 +126,7 @@ func Enchant(rest string, userId int) (bool, error) {
 
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> holds out their <ansi fg="itemname">%s</ansi> and slowly waves their hand over it. Runes appear to glow on the surface, which fade as they float away.`, user.Character.Name, matchItem.DisplayName()),
-				userId,
+				user.UserId,
 			)
 
 			user.SendText(
@@ -216,7 +210,7 @@ func Enchant(rest string, userId int) (bool, error) {
 
 		if roll < chanceToDestroy {
 			user.SendText(fmt.Sprintf(`The <ansi fg="itemname">%s</ansi> explodes in a shower of sparks!`, matchItem.DisplayName()))
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> holds out their <ansi fg="itemname">%s</ansi> and slowly waves their hand over it. The <ansi fg="itemname">%s</ansi> explodes in a shower of sparks!`, user.Character.Name, matchItem.DisplayName(), matchItem.DisplayName()), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> holds out their <ansi fg="itemname">%s</ansi> and slowly waves their hand over it. The <ansi fg="itemname">%s</ansi> explodes in a shower of sparks!`, user.Character.Name, matchItem.DisplayName(), matchItem.DisplayName()), user.UserId)
 			return true, nil
 		}
 
@@ -225,7 +219,7 @@ func Enchant(rest string, userId int) (bool, error) {
 
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> holds out their <ansi fg="itemname">%s</ansi> and slowly waves their hand over it. The <ansi fg="itemname">%s</ansi> glows briefly for a moment and then the glow fades away.`, user.Character.Name, matchItem.DisplayName(), matchItem.DisplayName()),
-			userId,
+			user.UserId,
 		)
 
 		user.SendText(

--- a/usercommands/skill.inspect.go
+++ b/usercommands/skill.inspect.go
@@ -18,13 +18,7 @@ Level 2 - Reveals weapon damage or uses an item has left.
 Level 3 - Reveals any stat modifiers an item has.
 Level 4 - Reveals special magical properties like elemental effects.
 */
-func Inspect(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Inspect(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.GetSkillLevel(skills.Inspect) == 0 {
 		user.SendText("You don't know how to inspect.")

--- a/usercommands/skill.inspect.go
+++ b/usercommands/skill.inspect.go
@@ -18,13 +18,7 @@ Level 2 - Reveals weapon damage or uses an item has left.
 Level 3 - Reveals any stat modifiers an item has.
 Level 4 - Reveals special magical properties like elemental effects.
 */
-func Inspect(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Inspect(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -63,7 +57,7 @@ func Inspect(rest string, userId int) (bool, error) {
 		)
 		room.SendText(
 			fmt.Sprintf(`<ansi fg="username">%s</ansi> inspects their <ansi fg="item">%s</ansi>...`, user.Character.Name, matchItem.DisplayName()),
-			userId,
+			user.UserId,
 		)
 
 		type inspectDetails struct {

--- a/usercommands/skill.map.go
+++ b/usercommands/skill.map.go
@@ -21,7 +21,7 @@ Level 2 - Map a 9x7 area
 Level 3 - Map a 13x9 area
 Level 4 - Map a 17x9 area, and enables the "wide" version.
 */
-func Map(rest string, user *users.UserRecord) (bool, error) {
+func Map(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Map)
 

--- a/usercommands/skill.map.go
+++ b/usercommands/skill.map.go
@@ -21,13 +21,7 @@ Level 2 - Map a 9x7 area
 Level 3 - Map a 13x9 area
 Level 4 - Map a 17x9 area, and enables the "wide" version.
 */
-func Map(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Map(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Map)
 
@@ -145,9 +139,9 @@ func Map(rest string, userId int) (bool, error) {
 
 	var rGraph *rooms.RoomGraph
 	if rest == "wide" {
-		rGraph = rooms.GenerateZoneMap(zone, roomId, userId, mapWidth, mapHeight, mapMode)
+		rGraph = rooms.GenerateZoneMap(zone, roomId, user.UserId, mapWidth, mapHeight, mapMode)
 	} else {
-		rGraph = rooms.GenerateZoneMap(zone, roomId, userId, int(math.Ceil(float64(mapWidth)/2))<<1, int(math.Ceil(float64(mapHeight)/2))<<1, mapMode)
+		rGraph = rooms.GenerateZoneMap(zone, roomId, user.UserId, int(math.Ceil(float64(mapWidth)/2))<<1, int(math.Ceil(float64(mapHeight)/2))<<1, mapMode)
 	}
 
 	if skillLevel > 4 {
@@ -166,7 +160,7 @@ func Map(rest string, userId int) (bool, error) {
 		}
 	}
 
-	if p := parties.Get(userId); p != nil {
+	if p := parties.Get(user.UserId); p != nil {
 		for _, uid := range p.GetMembers() {
 			if tmpUser := users.GetByUserId(uid); tmpUser != nil {
 

--- a/usercommands/skill.peep.go
+++ b/usercommands/skill.peep.go
@@ -21,7 +21,7 @@ Level 2 - Reveals detailed stats of a player or mob.
 Level 3 - Reveals detailed stats of the player or mob, plus equipment and items
 Level 4 - eveals detailed stats of the player or mob, plus equipment and items, and tells you the % chance of dropping items.
 */
-func Peep(rest string, user *users.UserRecord) (bool, error) {
+func Peep(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Peep)
 
@@ -46,11 +46,6 @@ func Peep(rest string, user *users.UserRecord) (bool, error) {
 			`You're using that skill just a little too fast.`,
 		)
 		return true, errors.New(`you're doing that too often`)
-	}
-
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	// valid peep targets are: mobs, players

--- a/usercommands/skill.peep.go
+++ b/usercommands/skill.peep.go
@@ -21,13 +21,7 @@ Level 2 - Reveals detailed stats of a player or mob.
 Level 3 - Reveals detailed stats of the player or mob, plus equipment and items
 Level 4 - eveals detailed stats of the player or mob, plus equipment and items, and tells you the % chance of dropping items.
 */
-func Peep(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Peep(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Peep)
 
@@ -130,7 +124,7 @@ func Peep(rest string, userId int) (bool, error) {
 
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> is peeping at <ansi fg="username">%s</ansi>.`, user.Character.Name, u.Character.Name),
-				userId,
+				user.UserId,
 				u.UserId)
 
 		} else if mobId > 0 {
@@ -189,7 +183,7 @@ func Peep(rest string, userId int) (bool, error) {
 
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> is peeping at %s.`, user.Character.Name, targetName),
-				userId,
+				user.UserId,
 			)
 
 		}

--- a/usercommands/skill.portal.go
+++ b/usercommands/skill.portal.go
@@ -20,11 +20,11 @@ Level 2 - Teleport back to the root of the area you are in
 Level 3 - Set a new destination for your portal teleportation
 Level 4 - Create a physical portal that you can share with players, or return through.
 */
-func Portal(rest string, user *users.UserRecord) (bool, error) {
+func Portal(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// This is a hack because using "portal" to enter an existing portal is very common
 	if rest == `` {
-		if handled, err := Go(`portal`, user); handled {
+		if handled, err := Go(`portal`, user, room); handled {
 			return handled, err
 		}
 	}
@@ -34,12 +34,6 @@ func Portal(rest string, user *users.UserRecord) (bool, error) {
 	if skillLevel == 0 {
 		user.SendText("You don't know how to portal.")
 		return true, errors.New(`you don't know how to portal`)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	// Establish the default portal location

--- a/usercommands/skill.portal.go
+++ b/usercommands/skill.portal.go
@@ -20,17 +20,11 @@ Level 2 - Teleport back to the root of the area you are in
 Level 3 - Set a new destination for your portal teleportation
 Level 4 - Create a physical portal that you can share with players, or return through.
 */
-func Portal(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Portal(rest string, user *users.UserRecord) (bool, error) {
 
 	// This is a hack because using "portal" to enter an existing portal is very common
 	if rest == `` {
-		if handled, err := Go(`portal`, userId); handled {
+		if handled, err := Go(`portal`, user); handled {
 			return handled, err
 		}
 	}
@@ -94,12 +88,12 @@ func Portal(rest string, userId int) (bool, error) {
 			user.SendText("You draw a quick symbol in the air with your finger, and the world warps around you. You seem to have moved.")
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> draws a quick symbol in the air, and is sucked into a portal!`, user.Character.Name),
-				userId,
+				user.UserId,
 			)
 			newRoom := rooms.LoadRoom(portalTargetRoomId)
 			newRoom.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> suddenly pops into existence!`, user.Character.Name),
-				userId,
+				user.UserId,
 			)
 		} else {
 			user.SendText("Oops, portal sad!")
@@ -115,7 +109,7 @@ func Portal(rest string, userId int) (bool, error) {
 			user.SendText("You enscribe a glowing pentagram on the ground with your finger, which then fades away. Your portals now lead to this area.")
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> enscribes a glowing pentagram on the ground with their finger. It quickly fades away.`, user.Character.Name),
-				userId,
+				user.UserId,
 			)
 		}
 
@@ -125,7 +119,7 @@ func Portal(rest string, userId int) (bool, error) {
 			user.SendText("You draw an arcane symbol in the air with your finger. Your portals now lead to their default location.")
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> draws a shape in the air with their finger. The floor trembles mildly, but then returns to normal.`, user.Character.Name),
-				userId,
+				user.UserId,
 			)
 		}
 	}
@@ -168,7 +162,7 @@ func Portal(rest string, userId int) (bool, error) {
 
 				if r1 := rooms.LoadRoom(portalRoomId1); r1 != nil {
 
-					if tmpExit, found := r1.FindTemporaryExitByUserId(userId); found {
+					if tmpExit, found := r1.FindTemporaryExitByUserId(user.UserId); found {
 						if r1.RemoveTemporaryExit(tmpExit) {
 							r1.SendText(
 								fmt.Sprintf("Suddenly, the %s before you snaps closed, leaving no evidence it ever existed.", glowingPortalColorized),
@@ -180,7 +174,7 @@ func Portal(rest string, userId int) (bool, error) {
 
 				if r2 := rooms.LoadRoom(portalRoomId2); r2 != nil {
 
-					if tmpExit, found := r2.FindTemporaryExitByUserId(userId); found {
+					if tmpExit, found := r2.FindTemporaryExitByUserId(user.UserId); found {
 						if r2.RemoveTemporaryExit(tmpExit) {
 							r2.SendText(
 								fmt.Sprintf("Suddenly, the %s before you snaps closed, leaving no evidence it ever existed.", glowingPortalColorized),
@@ -205,7 +199,7 @@ func Portal(rest string, userId int) (bool, error) {
 			newPortal := rooms.TemporaryRoomExit{
 				RoomId:  portalTargetRoomId,
 				Title:   fmt.Sprintf(`%s from <ansi fg="username">%s</ansi>`, glowingPortalColorized, user.Character.Name),
-				UserId:  userId,
+				UserId:  user.UserId,
 				Expires: time.Now().Add(time.Duration(portalLifeInSeconds) * time.Second),
 			}
 
@@ -219,7 +213,7 @@ func Portal(rest string, userId int) (bool, error) {
 			)
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> traces the shape of a doorway with their finger, and a %s appears!`, user.Character.Name, glowingPortalColorized),
-				userId,
+				user.UserId,
 			)
 
 			// Modify it for this room

--- a/usercommands/skill.protection.aid.go
+++ b/usercommands/skill.protection.aid.go
@@ -17,13 +17,7 @@ Protection Skill
 Level 1 - Aid (revive) a player
 Level 3 - Aid (revive) a player, even during combat
 */
-func Aid(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Aid(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -45,7 +39,7 @@ func Aid(rest string, userId int) (bool, error) {
 
 	aidPlayerId, _ := room.FindByName(rest, rooms.FindDowned)
 
-	if aidPlayerId == userId {
+	if aidPlayerId == user.UserId {
 		aidPlayerId = 0
 	}
 
@@ -74,7 +68,7 @@ func Aid(rest string, userId int) (bool, error) {
 			}
 
 			continueCasting := true
-			if handled, err := scripting.TrySpellScriptEvent(`onCast`, userId, 0, spellAggro); err == nil {
+			if handled, err := scripting.TrySpellScriptEvent(`onCast`, user.UserId, 0, spellAggro); err == nil {
 				continueCasting = handled
 			}
 

--- a/usercommands/skill.protection.aid.go
+++ b/usercommands/skill.protection.aid.go
@@ -17,13 +17,7 @@ Protection Skill
 Level 1 - Aid (revive) a player
 Level 3 - Aid (revive) a player, even during combat
 */
-func Aid(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Aid(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Protection)
 

--- a/usercommands/skill.protection.pray.go
+++ b/usercommands/skill.protection.pray.go
@@ -17,13 +17,7 @@ import (
 Protection Skill
 Level 4 - Pray to gods for a blessing
 */
-func Pray(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Pray(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -48,7 +42,7 @@ func Pray(rest string, userId int) (bool, error) {
 	prayPlayerId, prayMobId := 0, 0
 
 	if rest == `` {
-		prayPlayerId = userId
+		prayPlayerId = user.UserId
 	} else {
 		prayPlayerId, prayMobId = room.FindByName(rest)
 	}
@@ -67,7 +61,7 @@ func Pray(rest string, userId int) (bool, error) {
 
 	if prayPlayerId > 0 {
 
-		if prayPlayerId == userId {
+		if prayPlayerId == user.UserId {
 			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> begins to pray.`, user.Character.Name), user.UserId)
 		} else {
 			targetUser := users.GetByUserId(prayPlayerId)

--- a/usercommands/skill.protection.pray.go
+++ b/usercommands/skill.protection.pray.go
@@ -17,13 +17,7 @@ import (
 Protection Skill
 Level 4 - Pray to gods for a blessing
 */
-func Pray(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Pray(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Protection)
 

--- a/usercommands/skill.protection.rank.go
+++ b/usercommands/skill.protection.rank.go
@@ -13,13 +13,7 @@ import (
 Protection Skill
 Level 2 - Front/Backrank
 */
-func Rank(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Rank(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Protection)
 

--- a/usercommands/skill.protection.rank.go
+++ b/usercommands/skill.protection.rank.go
@@ -13,13 +13,7 @@ import (
 Protection Skill
 Level 2 - Front/Backrank
 */
-func Rank(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Rank(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -34,22 +28,22 @@ func Rank(rest string, userId int) (bool, error) {
 		return true, fmt.Errorf("you don't know how to change your combat rank.")
 	}
 
-	party := parties.Get(userId)
+	party := parties.Get(user.UserId)
 	if party == nil {
 		user.SendText("You must be in a party to change your combat rank.")
 		return true, fmt.Errorf("you must be in a party to change your combat rank.")
 	}
 
 	if rest == `back` {
-		party.SetRank(userId, `back`)
+		party.SetRank(user.UserId, `back`)
 	} else if rest == `front` {
-		party.SetRank(userId, `front`)
+		party.SetRank(user.UserId, `front`)
 	} else {
-		party.SetRank(userId, `middle`)
+		party.SetRank(user.UserId, `middle`)
 	}
 
-	user.SendText(fmt.Sprintf(`You are now fighting from the <ansi fg="magenta">%s</ansi> rank.`, party.GetRank(userId)))
-	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> is now fighting from the <ansi fg="magenta">%s</ansi> rank.`, user.Character.Name, party.GetRank(userId)), userId)
+	user.SendText(fmt.Sprintf(`You are now fighting from the <ansi fg="magenta">%s</ansi> rank.`, party.GetRank(user.UserId)))
+	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> is now fighting from the <ansi fg="magenta">%s</ansi> rank.`, user.Character.Name, party.GetRank(user.UserId)), user.UserId)
 
 	return true, nil
 }

--- a/usercommands/skill.scribe.go
+++ b/usercommands/skill.scribe.go
@@ -18,13 +18,7 @@ Level 2 - Scribe to a sign
 Level 3 - Scribe a hidden rune
 Level 4 - TODO
 */
-func Scribe(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Scribe(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Scribe)
 
@@ -86,13 +80,13 @@ func Scribe(rest string, userId int) (bool, error) {
 					user.SendText("You knock down the old sign and replace it with a new one.")
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> knocks down the old sign and replaces it with a new one.`, user.Character.Name),
-						userId,
+						user.UserId,
 					)
 				} else {
 					user.SendText("You find some junk wood and scrawl a message onto it.")
 					room.SendText(
 						fmt.Sprintf(`<ansi fg="username">%s</ansi> finds some junk wood and scrawls a message onto it.`, user.Character.Name),
-						userId,
+						user.UserId,
 					)
 				}
 			}
@@ -117,7 +111,7 @@ func Scribe(rest string, userId int) (bool, error) {
 			if len(rest) > 50 {
 				user.SendText("That won't fit! Keep it under 50 letters.")
 			} else {
-				if replaced := room.AddSign(rest, userId, 7); replaced {
+				if replaced := room.AddSign(rest, user.UserId, 7); replaced {
 					user.SendText("You scratch out the old rune and replace it with a new one.")
 				} else {
 					user.SendText("You scratch a rune into the floor.")

--- a/usercommands/skill.scribe.go
+++ b/usercommands/skill.scribe.go
@@ -18,20 +18,13 @@ Level 2 - Scribe to a sign
 Level 3 - Scribe a hidden rune
 Level 4 - TODO
 */
-func Scribe(rest string, user *users.UserRecord) (bool, error) {
+func Scribe(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Scribe)
 
 	if skillLevel == 0 {
 		user.SendText("You don't know how to scribe.")
 		return true, fmt.Errorf("you don't know how to scribe")
-	}
-
-	// Load current room details
-
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	// args should look like one of the following:

--- a/usercommands/skill.search.go
+++ b/usercommands/skill.search.go
@@ -26,13 +26,7 @@ Level 4 - You are always aware of hidden players/mobs in the area
 (Lvl 3) <ansi fg="skill">search</ansi> Finds special/unknown "things of interest" in the area.
 (Lvl 4) <ansi fg="skill">search</ansi> Doubles your chance of success when searching.
 */
-func Search(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Search(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Search)
 
@@ -60,7 +54,7 @@ func Search(rest string, userId int) (bool, error) {
 	user.SendText("You snoop around for a bit...\n")
 	room.SendText(
 		fmt.Sprintf(`<ansi fg="username">%s</ansi> is snooping around.`, user.Character.Name),
-		userId,
+		user.UserId,
 	)
 
 	// Check room exists
@@ -91,7 +85,7 @@ func Search(rest string, userId int) (bool, error) {
 		hiddenPlayers := []string{}
 
 		for _, pId := range room.GetPlayers() {
-			if pId == userId {
+			if pId == user.UserId {
 				continue
 			}
 			if p := users.GetByUserId(pId); p != nil {

--- a/usercommands/skill.search.go
+++ b/usercommands/skill.search.go
@@ -26,7 +26,7 @@ Level 4 - You are always aware of hidden players/mobs in the area
 (Lvl 3) <ansi fg="skill">search</ansi> Finds special/unknown "things of interest" in the area.
 (Lvl 4) <ansi fg="skill">search</ansi> Doubles your chance of success when searching.
 */
-func Search(rest string, user *users.UserRecord) (bool, error) {
+func Search(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Search)
 
@@ -40,12 +40,6 @@ func Search(rest string, user *users.UserRecord) (bool, error) {
 			fmt.Sprintf("You need to wait %d more rounds to use that skill again.", user.Character.GetCooldown(skills.Search.String())),
 		)
 		return true, fmt.Errorf("you're doing that too often")
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	// 10% + 1% for every 2 smarts

--- a/usercommands/skill.skulduggery.backstab.go
+++ b/usercommands/skill.skulduggery.backstab.go
@@ -18,7 +18,7 @@ import (
 SkullDuggery Skill
 Level 2 - Backstab
 */
-func Backstab(rest string, user *users.UserRecord) (bool, error) {
+func Backstab(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 
@@ -32,12 +32,6 @@ func Backstab(rest string, user *users.UserRecord) (bool, error) {
 	if !isSneaking {
 		user.SendText("You can't backstab unless you're hidden!")
 		return true, nil
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	// Do a check for whether these can backstab

--- a/usercommands/skill.skulduggery.backstab.go
+++ b/usercommands/skill.skulduggery.backstab.go
@@ -18,13 +18,7 @@ import (
 SkullDuggery Skill
 Level 2 - Backstab
 */
-func Backstab(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Backstab(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 
@@ -75,7 +69,7 @@ func Backstab(rest string, userId int) (bool, error) {
 		// If no argument supplied, attack whoever is attacking the player currently.
 		for _, mId := range room.GetMobs(rooms.FindFightingPlayer) {
 			m := mobs.GetInstance(mId)
-			if m.Character.Aggro != nil && m.Character.Aggro.UserId == userId {
+			if m.Character.Aggro != nil && m.Character.Aggro.UserId == user.UserId {
 				attackMobInstanceId = m.InstanceId
 				break
 			}
@@ -84,7 +78,7 @@ func Backstab(rest string, userId int) (bool, error) {
 		if attackMobInstanceId == 0 {
 			for _, uId := range room.GetPlayers(rooms.FindFightingPlayer) {
 				u := users.GetByUserId(uId)
-				if u.Character.Aggro != nil && u.Character.Aggro.UserId == userId {
+				if u.Character.Aggro != nil && u.Character.Aggro.UserId == user.UserId {
 					attackPlayerId = u.UserId
 					break
 				}
@@ -94,7 +88,7 @@ func Backstab(rest string, userId int) (bool, error) {
 		attackPlayerId, attackMobInstanceId = room.FindByName(rest)
 	}
 
-	if attackPlayerId == userId { // Can't attack self!
+	if attackPlayerId == user.UserId { // Can't attack self!
 		attackPlayerId = 0
 	}
 
@@ -107,7 +101,7 @@ func Backstab(rest string, userId int) (bool, error) {
 
 		m := mobs.GetInstance(attackMobInstanceId)
 
-		if m.Character.IsCharmed(userId) {
+		if m.Character.IsCharmed(user.UserId) {
 			user.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> is your friend!`, m.Character.Name))
 			return true, nil
 		}

--- a/usercommands/skill.skulduggery.bump.go
+++ b/usercommands/skill.skulduggery.bump.go
@@ -17,13 +17,7 @@ import (
 SkullDuggery Skill
 Level 3 - Backstab
 */
-func Bump(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Bump(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -43,7 +37,7 @@ func Bump(rest string, userId int) (bool, error) {
 		return true, nil
 	}
 
-	if room.AreMobsAttacking(userId) {
+	if room.AreMobsAttacking(user.UserId) {
 		user.SendText("You can't do that while you are under attack!")
 		return true, nil
 	}
@@ -102,7 +96,7 @@ func Bump(rest string, userId int) (bool, error) {
 
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> accidentally bumps into <ansi fg="mobname">%s</ansi>!`, user.Character.Name, m.Character.Name),
-				userId,
+				user.UserId,
 			)
 
 		}
@@ -147,7 +141,7 @@ func Bump(rest string, userId int) (bool, error) {
 
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> accidentally bumps into <ansi fg="username">%s</ansi>!`, user.Character.Name, p.Character.Name),
-				userId,
+				user.UserId,
 				pickPlayerId,
 			)
 

--- a/usercommands/skill.skulduggery.bump.go
+++ b/usercommands/skill.skulduggery.bump.go
@@ -17,13 +17,7 @@ import (
 SkullDuggery Skill
 Level 3 - Backstab
 */
-func Bump(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Bump(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 

--- a/usercommands/skill.skulduggery.pickpocket.go
+++ b/usercommands/skill.skulduggery.pickpocket.go
@@ -18,13 +18,7 @@ import (
 SkullDuggery Skill
 Level 4 - Pickpocket
 */
-func Pickpocket(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Pickpocket(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -47,7 +41,7 @@ func Pickpocket(rest string, userId int) (bool, error) {
 		return true, nil
 	}
 
-	if room.AreMobsAttacking(userId) {
+	if room.AreMobsAttacking(user.UserId) {
 		user.SendText("You can't do that while you are under attack!")
 		return true, nil
 	}
@@ -131,7 +125,7 @@ func Pickpocket(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> gets caught trying to pick the pockets of <ansi fg="mobname">%s</ansi>!`, user.Character.Name, m.Character.Name),
-					userId,
+					user.UserId,
 				)
 
 				user.Character.CancelBuffsWithFlag(buffs.Hidden)
@@ -226,7 +220,7 @@ func Pickpocket(rest string, userId int) (bool, error) {
 
 				room.SendText(
 					fmt.Sprintf(`<ansi fg="username">%s</ansi> gets caught trying to pick the pockets of <ansi fg="username">%s</ansi>!`, user.Character.Name, p.Character.Name),
-					userId,
+					user.UserId,
 				)
 
 				user.Character.CancelBuffsWithFlag(buffs.Hidden)

--- a/usercommands/skill.skulduggery.pickpocket.go
+++ b/usercommands/skill.skulduggery.pickpocket.go
@@ -18,13 +18,7 @@ import (
 SkullDuggery Skill
 Level 4 - Pickpocket
 */
-func Pickpocket(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 

--- a/usercommands/skill.skulduggery.sneak.go
+++ b/usercommands/skill.skulduggery.sneak.go
@@ -1,8 +1,6 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/buffs"
 	"github.com/volte6/mud/events"
 	"github.com/volte6/mud/rooms"
@@ -14,13 +12,7 @@ import (
 SkullDuggery Skill
 Level 1 - Sneak
 */
-func Sneak(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Sneak(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 
@@ -47,7 +39,7 @@ func Sneak(rest string, userId int) (bool, error) {
 	}
 
 	events.AddToQueue(events.Buff{
-		UserId:        userId,
+		UserId:        user.UserId,
 		MobInstanceId: 0,
 		BuffId:        9,
 	})

--- a/usercommands/skill.skulduggery.sneak.go
+++ b/usercommands/skill.skulduggery.sneak.go
@@ -12,7 +12,7 @@ import (
 SkullDuggery Skill
 Level 1 - Sneak
 */
-func Sneak(rest string, user *users.UserRecord) (bool, error) {
+func Sneak(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 

--- a/usercommands/skill.tame.go
+++ b/usercommands/skill.tame.go
@@ -23,7 +23,7 @@ Level 2 - Tame up to 3 creatures
 Level 3 - Tame up to 4 creatures
 Level 4 - Tame up to 5 creatures
 */
-func Tame(rest string, user *users.UserRecord) (bool, error) {
+func Tame(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Tame)
 	if skillLevel == 0 {
@@ -61,11 +61,6 @@ func Tame(rest string, user *users.UserRecord) (bool, error) {
 		user.SendText(`<ansi fg="command">help tame</ansi> to find out more.`)
 
 		return true, nil
-	}
-
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	// valid peep targets are: mobs, players

--- a/usercommands/skill.tame.go
+++ b/usercommands/skill.tame.go
@@ -23,13 +23,7 @@ Level 2 - Tame up to 3 creatures
 Level 3 - Tame up to 4 creatures
 Level 4 - Tame up to 5 creatures
 */
-func Tame(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Tame(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Tame)
 	if skillLevel == 0 {
@@ -81,7 +75,7 @@ func Tame(rest string, userId int) (bool, error) {
 
 		if mob := mobs.GetInstance(mobId); mob != nil {
 
-			if mob.Character.IsCharmed(userId) {
+			if mob.Character.IsCharmed(user.UserId) {
 				user.SendText("They are already charmed.")
 				return true, errors.New(`they are already charmed`)
 			}
@@ -95,7 +89,7 @@ func Tame(rest string, userId int) (bool, error) {
 			}
 
 			continueCasting := true
-			if handled, err := scripting.TrySpellScriptEvent(`onCast`, userId, 0, spellAggro); err == nil {
+			if handled, err := scripting.TrySpellScriptEvent(`onCast`, user.UserId, 0, spellAggro); err == nil {
 				continueCasting = handled
 			}
 

--- a/usercommands/skill.track.go
+++ b/usercommands/skill.track.go
@@ -30,13 +30,7 @@ Level 2 - Display all players and mobs to recently walk through here
 Level 3 - Shows exit information for all tracked players or mobs
 Level 4 - Specify a mob or username and every room you enter will tell you what exit they took.
 */
-func Track(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Track(rest string, user *users.UserRecord) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Track)
 
@@ -114,7 +108,7 @@ func Track(rest string, userId int) (bool, error) {
 
 		for uId, timeLeft := range room.Visitors(rooms.VisitorUser) {
 
-			if uId == userId {
+			if uId == user.UserId {
 				continue
 			}
 
@@ -226,7 +220,7 @@ func Track(rest string, userId int) (bool, error) {
 
 			for uId, _ := range room.Visitors(rooms.VisitorUser) {
 
-				if uId == userId {
+				if uId == user.UserId {
 					continue
 				}
 
@@ -333,7 +327,7 @@ func Track(rest string, userId int) (bool, error) {
 
 			for uId, timeLeft := range room.Visitors(rooms.VisitorUser) {
 
-				if uId == userId {
+				if uId == user.UserId {
 					continue
 				}
 

--- a/usercommands/skill.track.go
+++ b/usercommands/skill.track.go
@@ -30,19 +30,13 @@ Level 2 - Display all players and mobs to recently walk through here
 Level 3 - Shows exit information for all tracked players or mobs
 Level 4 - Specify a mob or username and every room you enter will tell you what exit they took.
 */
-func Track(rest string, user *users.UserRecord) (bool, error) {
+func Track(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Track)
 
 	if skillLevel == 0 {
 		user.SendText("You don't know how to track.")
 		return true, errors.New(`you don't know how to track`)
-	}
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
 	}
 
 	currentMobs := room.GetMobs()

--- a/usercommands/skills.go
+++ b/usercommands/skills.go
@@ -3,6 +3,7 @@ package usercommands
 import (
 	"fmt"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
@@ -13,7 +14,7 @@ type SkillsOptions struct {
 	SkillCooldowns map[string]int
 }
 
-func Skills(rest string, user *users.UserRecord) (bool, error) {
+func Skills(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	allSkills := user.Character.GetSkills()
 	allCooldowns := map[string]int{}

--- a/usercommands/skills.go
+++ b/usercommands/skills.go
@@ -13,13 +13,7 @@ type SkillsOptions struct {
 	SkillCooldowns map[string]int
 }
 
-func Skills(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Skills(rest string, user *users.UserRecord) (bool, error) {
 
 	allSkills := user.Character.GetSkills()
 	allCooldowns := map[string]int{}

--- a/usercommands/spells.go
+++ b/usercommands/spells.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Spells(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf(`user %d not found`, userId)
-	}
+func Spells(rest string, user *users.UserRecord) (bool, error) {
 
 	headers := []string{`SpellId`, `Name`, `Description`, `Target`, `MPs`, `Wait`, `Casts`, `% Chance`}
 

--- a/usercommands/spells.go
+++ b/usercommands/spells.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/spells"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Spells(rest string, user *users.UserRecord) (bool, error) {
+func Spells(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	headers := []string{`SpellId`, `Name`, `Description`, `Target`, `MPs`, `Wait`, `Casts`, `% Chance`}
 

--- a/usercommands/start.go
+++ b/usercommands/start.go
@@ -15,7 +15,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Start(rest string, user *users.UserRecord) (bool, error) {
+func Start(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if user.Character.RoomId != -1 {
 		return false, errors.New(`only allowed in the void`)
@@ -46,7 +46,7 @@ func Start(rest string, user *users.UserRecord) (bool, error) {
 		if question.Response == `?` {
 
 			question.RejectResponse()
-			return Help(`races`, user)
+			return Help(`races`, user, room)
 
 		}
 

--- a/usercommands/start.go
+++ b/usercommands/start.go
@@ -15,13 +15,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Start(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Start(rest string, user *users.UserRecord) (bool, error) {
 
 	if user.Character.RoomId != -1 {
 		return false, errors.New(`only allowed in the void`)
@@ -52,7 +46,7 @@ func Start(rest string, userId int) (bool, error) {
 		if question.Response == `?` {
 
 			question.RejectResponse()
-			return Help(`races`, userId)
+			return Help(`races`, user)
 
 		}
 
@@ -127,7 +121,7 @@ func Start(rest string, userId int) (bool, error) {
 
 		if _, err := scripting.TryRoomScriptEvent(`onEnter`, user.UserId, int(rid)); err == nil {
 
-			rooms.MoveToRoom(userId, int(rid))
+			rooms.MoveToRoom(user.UserId, int(rid))
 			return true, nil
 		}
 

--- a/usercommands/stash.go
+++ b/usercommands/stash.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Stash(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Stash(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -31,7 +25,7 @@ func Stash(rest string, userId int) (bool, error) {
 	} else {
 		// Swap the item location
 
-		matchItem.StashedBy = userId
+		matchItem.StashedBy = user.UserId
 
 		room.AddItem(matchItem, true)
 		user.Character.RemoveItem(matchItem)
@@ -44,11 +38,11 @@ func Stash(rest string, userId int) (bool, error) {
 		if !isSneaking {
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> is attempting to look unsuspicious.`, user.Character.Name),
-				userId)
+				user.UserId)
 		}
 
 		// Trigger lost event
-		scripting.TryItemScriptEvent(`onLost`, matchItem, userId)
+		scripting.TryItemScriptEvent(`onLost`, matchItem, user.UserId)
 	}
 
 	return true, nil

--- a/usercommands/stash.go
+++ b/usercommands/stash.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Stash(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Stash(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/usercommands/status.go
+++ b/usercommands/status.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/term"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Status(rest string, user *users.UserRecord) (bool, error) {
+func Status(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	//possibleStatuses := []string{`strength`, `speed`, `smarts`, `vitality`, `mysticism`, `perception`}
 
@@ -107,7 +108,7 @@ func Status(rest string, user *users.UserRecord) (bool, error) {
 	tplTxt, _ := templates.Process("character/status", user)
 	user.SendText(tplTxt)
 
-	Inventory(``, user)
+	Inventory(``, user, room)
 
 	return true, nil
 }

--- a/usercommands/status.go
+++ b/usercommands/status.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Status(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Status(rest string, user *users.UserRecord) (bool, error) {
 
 	//possibleStatuses := []string{`strength`, `speed`, `smarts`, `vitality`, `mysticism`, `perception`}
 
@@ -113,7 +107,7 @@ func Status(rest string, userId int) (bool, error) {
 	tplTxt, _ := templates.Process("character/status", user)
 	user.SendText(tplTxt)
 
-	Inventory(``, userId)
+	Inventory(``, user)
 
 	return true, nil
 }

--- a/usercommands/storage.go
+++ b/usercommands/storage.go
@@ -14,14 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Storage(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Storage(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if !room.IsStorage {
 		user.SendText(`You are not at a storage location.` + term.CRLFStr)
@@ -69,7 +62,7 @@ func Storage(rest string, user *users.UserRecord) (bool, error) {
 		if itemName == `all` {
 
 			for _, itm := range user.Character.GetAllBackpackItems() {
-				Storage(fmt.Sprintf(`add !%d`, itm.ItemId), user)
+				Storage(fmt.Sprintf(`add !%d`, itm.ItemId), user, room)
 
 				spaceLeft--
 				if spaceLeft < 0 {
@@ -100,7 +93,7 @@ func Storage(rest string, user *users.UserRecord) (bool, error) {
 		if itemName == `all` {
 
 			for _, itm := range user.ItemStorage.GetItems() {
-				Storage(fmt.Sprintf(`remove !%d`, itm.ItemId), user)
+				Storage(fmt.Sprintf(`remove !%d`, itm.ItemId), user, room)
 			}
 
 			return true, nil

--- a/usercommands/storage.go
+++ b/usercommands/storage.go
@@ -14,13 +14,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Storage(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Storage(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 
@@ -75,7 +69,7 @@ func Storage(rest string, userId int) (bool, error) {
 		if itemName == `all` {
 
 			for _, itm := range user.Character.GetAllBackpackItems() {
-				Storage(fmt.Sprintf(`add !%d`, itm.ItemId), userId)
+				Storage(fmt.Sprintf(`add !%d`, itm.ItemId), user)
 
 				spaceLeft--
 				if spaceLeft < 0 {
@@ -99,14 +93,14 @@ func Storage(rest string, userId int) (bool, error) {
 		user.SendText(fmt.Sprintf(`You placed the <ansi fg="itemname">%s</ansi> into storage.`, itm.DisplayName()))
 
 		// Trigger lost event
-		scripting.TryItemScriptEvent(`onLost`, itm, userId)
+		scripting.TryItemScriptEvent(`onLost`, itm, user.UserId)
 
 	} else if action == `remove` {
 
 		if itemName == `all` {
 
 			for _, itm := range user.ItemStorage.GetItems() {
-				Storage(fmt.Sprintf(`remove !%d`, itm.ItemId), userId)
+				Storage(fmt.Sprintf(`remove !%d`, itm.ItemId), user)
 			}
 
 			return true, nil
@@ -141,7 +135,7 @@ func Storage(rest string, userId int) (bool, error) {
 
 			user.SendText(fmt.Sprintf(`You removed the <ansi fg="itemname">%s</ansi> from storage.`, itm.DisplayName()))
 
-			scripting.TryItemScriptEvent(`onFound`, itm, userId)
+			scripting.TryItemScriptEvent(`onFound`, itm, user.UserId)
 
 		} else {
 			user.SendText(`You can't carry that!`)

--- a/usercommands/suicide.go
+++ b/usercommands/suicide.go
@@ -16,15 +16,9 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Suicide(rest string, userId int) (bool, error) {
+func Suicide(rest string, user *users.UserRecord) (bool, error) {
 
 	config := configs.GetConfig()
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
 
 	if user.Character.Zone == `Shadow Realm` {
 		user.SendText(`You're already dead!`)
@@ -67,14 +61,14 @@ func Suicide(rest string, userId int) (bool, error) {
 
 			// Unequip everything
 			for _, itm := range user.Character.GetAllWornItems() {
-				Remove(itm.Name(), userId)
+				Remove(itm.Name(), user)
 			}
 			// drop all items / gold
-			Drop("all", userId)
+			Drop("all", user)
 
 			user.Character = characters.New()
 
-			rooms.MoveToRoom(userId, -1)
+			rooms.MoveToRoom(user.UserId, -1)
 
 			return true, nil
 		}
@@ -86,25 +80,25 @@ func Suicide(rest string, userId int) (bool, error) {
 		for _, itm := range user.Character.GetAllWornItems() {
 			if util.Rand(100) < chanceInt {
 
-				Remove(itm.Name(), userId)
+				Remove(itm.Name(), user)
 
-				Drop(itm.Name(), userId)
+				Drop(itm.Name(), user)
 
 			}
 		}
 	}
 
 	if user.Character.Gold > 0 {
-		Drop(fmt.Sprintf(`%d gold`, user.Character.Gold), userId)
+		Drop(fmt.Sprintf(`%d gold`, user.Character.Gold), user)
 	}
 
 	if config.OnDeathAlwaysDropBackpack {
-		Drop("all", userId)
+		Drop("all", user)
 	} else if config.OnDeathEquipmentDropChance >= 0 {
 		chanceInt := int(config.OnDeathEquipmentDropChance * 100)
 		for _, itm := range user.Character.GetAllBackpackItems() {
 			if util.Rand(100) < chanceInt {
-				Drop(itm.Name(), userId)
+				Drop(itm.Name(), user)
 			}
 		}
 	}
@@ -138,7 +132,7 @@ func Suicide(rest string, userId int) (bool, error) {
 
 	user.Character.KD.AddDeath()
 
-	rooms.MoveToRoom(userId, 75)
+	rooms.MoveToRoom(user.UserId, 75)
 
 	return true, nil
 }

--- a/usercommands/suicide.go
+++ b/usercommands/suicide.go
@@ -16,18 +16,13 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Suicide(rest string, user *users.UserRecord) (bool, error) {
+func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	config := configs.GetConfig()
 
 	if user.Character.Zone == `Shadow Realm` {
 		user.SendText(`You're already dead!`)
 		return true, errors.New(`already dead`)
-	}
-
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf("room %d not found", user.Character.RoomId)
 	}
 
 	if user.Character.HasBuffFlag(buffs.ReviveOnDeath) {
@@ -61,10 +56,10 @@ func Suicide(rest string, user *users.UserRecord) (bool, error) {
 
 			// Unequip everything
 			for _, itm := range user.Character.GetAllWornItems() {
-				Remove(itm.Name(), user)
+				Remove(itm.Name(), user, room)
 			}
 			// drop all items / gold
-			Drop("all", user)
+			Drop("all", user, room)
 
 			user.Character = characters.New()
 
@@ -80,25 +75,25 @@ func Suicide(rest string, user *users.UserRecord) (bool, error) {
 		for _, itm := range user.Character.GetAllWornItems() {
 			if util.Rand(100) < chanceInt {
 
-				Remove(itm.Name(), user)
+				Remove(itm.Name(), user, room)
 
-				Drop(itm.Name(), user)
+				Drop(itm.Name(), user, room)
 
 			}
 		}
 	}
 
 	if user.Character.Gold > 0 {
-		Drop(fmt.Sprintf(`%d gold`, user.Character.Gold), user)
+		Drop(fmt.Sprintf(`%d gold`, user.Character.Gold), user, room)
 	}
 
 	if config.OnDeathAlwaysDropBackpack {
-		Drop("all", user)
+		Drop("all", user, room)
 	} else if config.OnDeathEquipmentDropChance >= 0 {
 		chanceInt := int(config.OnDeathEquipmentDropChance * 100)
 		for _, itm := range user.Character.GetAllBackpackItems() {
 			if util.Rand(100) < chanceInt {
-				Drop(itm.Name(), user)
+				Drop(itm.Name(), user, room)
 			}
 		}
 	}

--- a/usercommands/time.go
+++ b/usercommands/time.go
@@ -1,18 +1,11 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/gametime"
 	"github.com/volte6/mud/users"
 )
 
-func Time(rest string, userId int) (bool, error) {
-
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Time(rest string, user *users.UserRecord) (bool, error) {
 
 	gd := gametime.GetDate()
 

--- a/usercommands/time.go
+++ b/usercommands/time.go
@@ -2,10 +2,11 @@ package usercommands
 
 import (
 	"github.com/volte6/mud/gametime"
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 )
 
-func Time(rest string, user *users.UserRecord) (bool, error) {
+func Time(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	gd := gametime.GetDate()
 

--- a/usercommands/train.go
+++ b/usercommands/train.go
@@ -23,14 +23,7 @@ type TrainingOptions struct {
 	Options        []TrainingOption
 }
 
-func Train(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Train(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if len(room.SkillTraining) == 0 {
 		user.SendText(`You must find a trainer to perform training.`)

--- a/usercommands/train.go
+++ b/usercommands/train.go
@@ -23,13 +23,7 @@ type TrainingOptions struct {
 	Options        []TrainingOption
 }
 
-func Train(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Train(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 
@@ -134,12 +128,12 @@ func Train(rest string, userId int) (bool, error) {
 			user.SendText(`The trainer pokes you on your chest, "I think you're in the wrong place, pal."`)
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> looks a little confused.`, user.Character.Name),
-				userId)
+				user.UserId)
 		} else if currentLevel == 4 { // Max level
 			user.SendText(`The trainer chuckles, "I admire your ambition, but you have already mastered that skill!"`)
 			room.SendText(
 				fmt.Sprintf(`The trainer chuckles and says something you can't quite make out to <ansi fg="username">%s</ansi>`, user.Character.Name),
-				userId)
+				user.UserId)
 		} else if currentLevel < trainingRange.Min-1 { // Not high enough level
 			user.SendText(`The trainer shakes his head, "You aren't ready to train here."`)
 		} else {
@@ -150,7 +144,7 @@ func Train(rest string, userId int) (bool, error) {
 				user.SendText(`The trainer pulls you close and says quietly, "You aren't ready yet. Return when you have more experience."`)
 				room.SendText(
 					fmt.Sprintf(`The trainer pulls <ansi fg="username">%s</ansi> close and mumbles something in their ear.`, user.Character.Name),
-					userId)
+					user.UserId)
 			} else {
 
 				// Take away the cost
@@ -174,7 +168,7 @@ func Train(rest string, userId int) (bool, error) {
 				user.SendText(`"Congratulations!", the trainer exclaims. You are now a little more prepared for the world.`)
 				room.SendText(
 					fmt.Sprintf(`The trainer shakes <ansi fg="username">%ss</ansi> hand while congratulating them. Must be nice.`, user.Character.Name),
-					userId)
+					user.UserId)
 
 				if match == string(skills.Tame) {
 					if newLevel == 1 {

--- a/usercommands/trash.go
+++ b/usercommands/trash.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Trash(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Trash(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -40,7 +34,7 @@ func Trash(rest string, userId int) (bool, error) {
 		if !isSneaking {
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> destroys <ansi fg="item">%s</ansi>...`, user.Character.Name, matchItem.DisplayName()),
-				userId)
+				user.UserId)
 		}
 
 		iSpec := matchItem.GetSpec()
@@ -56,7 +50,7 @@ func Trash(rest string, userId int) (bool, error) {
 			fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi>%s!`, grantXP, xpMsgExtra))
 
 		// Trigger lost event
-		scripting.TryItemScriptEvent(`onLost`, matchItem, userId)
+		scripting.TryItemScriptEvent(`onLost`, matchItem, user.UserId)
 
 	}
 

--- a/usercommands/trash.go
+++ b/usercommands/trash.go
@@ -9,13 +9,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Trash(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Trash(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/usercommands/unlock.go
+++ b/usercommands/unlock.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Unlock(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Unlock(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -57,7 +51,7 @@ func Unlock(rest string, userId int) (bool, error) {
 			room.Containers[containerName] = container
 
 			user.SendText(fmt.Sprintf(`You use a key to unlock the <ansi fg="container">%s</ansi>.`, containerName))
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to unlock the <ansi fg="container">%s</ansi>.`, user.Character.Name, containerName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to unlock the <ansi fg="container">%s</ansi>.`, user.Character.Name, containerName), user.UserId)
 		} else if hasBackpackKey {
 
 			itmSpec := backpackKeyItm.GetSpec()
@@ -73,7 +67,7 @@ func Unlock(rest string, userId int) (bool, error) {
 			user.SendText(fmt.Sprintf(`You use your <ansi fg="item">%s</ansi> to lock the <ansi fg="container">%s</ansi>, and add it to your key ring for the future.`, itmSpec.Name, containerName))
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to lock the <ansi fg="container">%s</ansi>.`, user.Character.Name, containerName),
-				userId)
+				user.UserId)
 		} else {
 			user.SendText(`You do not have the key for that. Maybe you could <ansi fg="command">picklock</ansi> the lock.`)
 		}
@@ -103,7 +97,7 @@ func Unlock(rest string, userId int) (bool, error) {
 			room.Exits[exitName] = exitInfo
 
 			user.SendText(fmt.Sprintf(`You use a key to unlock the <ansi fg="exit">%s</ansi> lock.`, exitName))
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to unlock the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), userId)
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to unlock the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName), user.UserId)
 		} else if hasBackpackKey {
 
 			itmSpec := backpackKeyItm.GetSpec()
@@ -119,7 +113,7 @@ func Unlock(rest string, userId int) (bool, error) {
 			user.SendText(fmt.Sprintf(`You use your <ansi fg="item">%s</ansi> to unlock the <ansi fg="exit">%s</ansi> exit, and add it to your key ring for the future.`, itmSpec.Name, exitName))
 			room.SendText(
 				fmt.Sprintf(`<ansi fg="username">%s</ansi> uses a key to unlock the <ansi fg="exit">%s</ansi> lock`, user.Character.Name, exitName),
-				userId)
+				user.UserId)
 		} else {
 			user.SendText(`You do not have the key for that. Maybe you could <ansi fg="command">picklock</ansi> the lock.`)
 		}

--- a/usercommands/unlock.go
+++ b/usercommands/unlock.go
@@ -10,13 +10,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Unlock(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Unlock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/usercommands/use.go
+++ b/usercommands/use.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Use(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Use(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -43,11 +37,11 @@ func Use(rest string, userId int) (bool, error) {
 		user.Character.CancelBuffsWithFlag(buffs.Hidden)
 
 		user.SendText(fmt.Sprintf(`You use the <ansi fg="itemname">%s</ansi>.`, matchItem.DisplayName()))
-		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses their <ansi fg="itemname">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()), userId)
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> uses their <ansi fg="itemname">%s</ansi>.`, user.Character.Name, matchItem.DisplayName()), user.UserId)
 
 		// If no more uses, will be lost, so trigger event
 		if usesLeft := user.Character.UseItem(matchItem); usesLeft < 1 {
-			scripting.TryItemScriptEvent(`onLost`, matchItem, userId)
+			scripting.TryItemScriptEvent(`onLost`, matchItem, user.UserId)
 		}
 
 		for _, buffId := range itemSpec.BuffIds {

--- a/usercommands/use.go
+++ b/usercommands/use.go
@@ -11,13 +11,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Use(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Use(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/usercommands/usercommands.go
+++ b/usercommands/usercommands.go
@@ -187,7 +187,7 @@ func GetHelpSuggestions(text string, includeAdmin bool) []string {
 }
 
 // Signature of user command
-type UserCommand func(rest string, userId int) (bool, error)
+type UserCommand func(rest string, user *users.UserRecord) (bool, error)
 
 func TryCommand(cmd string, rest string, userId int) (bool, error) {
 
@@ -265,7 +265,8 @@ func TryCommand(cmd string, rest string, userId int) (bool, error) {
 				util.TrackTime(`usr-cmd[`+cmd+`]`, time.Since(start).Seconds())
 			}()
 
-			handled, err := cmdInfo.Func(rest, userId)
+			// Run the command here
+			handled, err := cmdInfo.Func(rest, user)
 			return handled, err
 
 		}
@@ -277,13 +278,13 @@ func TryCommand(cmd string, rest string, userId int) (bool, error) {
 		util.TrackTime(`usr-cmd[go]`, time.Since(start).Seconds())
 	}()
 
-	if handled, err := Go(cmd, userId); handled {
+	if handled, err := Go(cmd, user); handled {
 		return handled, err
 	}
 	// end "go" attempt
 
 	if emoteText, ok := emoteAliases[cmd]; ok {
-		handled, err := Emote(emoteText, userId)
+		handled, err := Emote(emoteText, user)
 		return handled, err
 	}
 
@@ -292,7 +293,7 @@ func TryCommand(cmd string, rest string, userId int) (bool, error) {
 		if len(rest) > 0 {
 			castCmd += ` ` + rest
 		}
-		return Cast(castCmd, userId)
+		return Cast(castCmd, user)
 	}
 
 	return false, nil

--- a/usercommands/whisper.go
+++ b/usercommands/whisper.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/util"
 )
 
-func Whisper(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Whisper(rest string, user *users.UserRecord) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/usercommands/whisper.go
+++ b/usercommands/whisper.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
 	"github.com/volte6/mud/util"
 )
 
-func Whisper(rest string, user *users.UserRecord) (bool, error) {
+func Whisper(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/usercommands/who.go
+++ b/usercommands/who.go
@@ -1,20 +1,12 @@
 package usercommands
 
 import (
-	"fmt"
-
 	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/templates"
 	"github.com/volte6/mud/users"
 )
 
-func Who(rest string, user *users.UserRecord) (bool, error) {
-
-	// Load current room details
-	room := rooms.LoadRoom(user.Character.RoomId)
-	if room == nil {
-		return false, fmt.Errorf(`room %d not found`, user.Character.RoomId)
-	}
+func Who(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	details := room.GetRoomDetails(user)
 

--- a/usercommands/who.go
+++ b/usercommands/who.go
@@ -8,13 +8,7 @@ import (
 	"github.com/volte6/mud/users"
 )
 
-func Who(rest string, userId int) (bool, error) {
-
-	// Load user details
-	user := users.GetByUserId(userId)
-	if user == nil { // Something went wrong. User not found.
-		return false, fmt.Errorf("user %d not found", userId)
-	}
+func Who(rest string, user *users.UserRecord) (bool, error) {
 
 	// Load current room details
 	room := rooms.LoadRoom(user.Character.RoomId)


### PR DESCRIPTION
# Motivation

The command function definition has changed over time as we gain experience in how we actually use it vs. the original ideation. This is another step in simplicity.

Commands accept an argument (`userId int` or `mobInstanceId int`) which defines who is invoking the command. As a result every command function must do a lookup of the userId or mobInstanceId as well as validate it (make sure it's not null), which is a lot of redundant code. Originally it was thought that not all commands would need access to the user object. This is true, but not true very often. So, to simplify we will just pass the user/mob object pointer to the function instead of their identifier.

Additionally updated to pass a pointer to the `Room` object to the command for the same reasons.

# Changes
* Improved messaging of `character` command menu/responses.
* `type UserCommand func(rest string, userId int) (bool, error)`
  * changed to `type UserCommand func(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)`
  * Lots of redundant `user := users.GetByUserId(userId)` removed as a result
  * Lots of redundant `room := rooms.LoadRoom(user.Character.RoomId)` removed as a result
* `type MobCommand func(rest string, mobId int) (bool, error)`
  * changed to `type UserCommand func(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error)`
  * Lots of redundant `mob := mobs.GetInstance(mobId)` removed as a result
  * Lots of redundant `room := rooms.LoadRoom(mob.Character.RoomId)` removed as a result
