### PR TITLE
Nouns

### DIFF
--- a/_datafiles/ansi-aliases.yaml
+++ b/_datafiles/ansi-aliases.yaml
@@ -129,6 +129,12 @@ color8:
   questflag: 3
   highlight: 90
   saytext: 93 # bright yellow
+  alert-5: 9
+  alert-4: 1
+  alert-3: 1
+  alert-2: 1
+  alert-1: 1
+  noun: 7
 color256:
   table-title: 2
   userid: black
@@ -252,3 +258,9 @@ color256:
   questflag: 187
   highlight: 238
   saytext: 230
+  alert-5: 196
+  alert-4: 203
+  alert-3: 210
+  alert-2: 210
+  alert-1: 217
+  noun: 151

--- a/_datafiles/ansi-aliases.yaml
+++ b/_datafiles/ansi-aliases.yaml
@@ -263,4 +263,4 @@ color256:
   alert-3: 210
   alert-2: 210
   alert-1: 217
-  noun: 151
+  noun: 115

--- a/_datafiles/rooms/frostfang/73.yaml
+++ b/_datafiles/rooms/frostfang/73.yaml
@@ -17,5 +17,24 @@ biome: city
 exits:
   west:
     roomid: 72
+nouns:
+  aurora: The sky above is occasionally illuminated by the soft, swirling colors of
+    an aurora, casting a magical glow across the entire garden.
+  bench: A small wooden bench, covered in a fine layer of frost, sits beside the frozen
+    pond, offering a place to rest and take in the beauty of the garden.
+  evergreens: Tall evergreens loom above, their snow-laden branches standing vigil
+    over the garden, their presence both protective and serene.
+  ferns: These hardy plants sway gently in the breeze, their leaves shimmering under
+    the weight of delicate frost.
+  moonflowers: These ethereal flowers line the pathways, glowing faintly in the moonlight,
+    their luminescence lighting the way through the garden.
+  pond: The surface of the pond is a perfect sheet of ice, its smooth surface reflecting
+    the snowfall and the occasional flicker of auroras overhead.
+  roses: Pale, icy petals glitter like gemstones, their fragile beauty enhanced by
+    a thin layer of frost that sparkles in the light.
+  table: A simple wooden table stands beside the bench, its surface coated with frost,
+    as if waiting for an icy tea party that never happened.
+  winterberries: Clusters of bright red berries offer a stark contrast to the surrounding
+    whiteness, nestled snugly beneath the evergreen boughs.
 items:
 - itemid: 10

--- a/_datafiles/templates/admincommands/help/command.room.template
+++ b/_datafiles/templates/admincommands/help/command.room.template
@@ -24,6 +24,11 @@ Set a property of the room. This updates basic properties of the room you are in
         <ansi fg="command">zone</ansi> (string)        - e.g. <ansi fg="command">room set zone "trash"</ansi>
         <ansi fg="command">spawninfo clear</ansi>      <ansi fg="red">CAREFUL! CLEARS SPAWN INFO!</ansi>
 
+    Nouns:
+        Room nouns are extra descriptive tags that can be "looked" at by players.
+        <ansi fg="command">room nouns</ansi> - List all nouns for the room
+        <ansi fg="command">room noun [name] [description[</ansi> - Add or overwrite a noun
+
 <ansi fg="command">room exit [exit_name] [room_id]</ansi> - e.g. <ansi fg="command">room exit west 159</ansi>
 This will create a new exit that links to a specific room_id using the exit_name provided.
 <ansi fg="red-bold">!Beware!</ansi> if the spacial relationship with compass direction rooms is done incorrectly, 

--- a/_datafiles/templates/character/experience.template
+++ b/_datafiles/templates/character/experience.template
@@ -1,3 +1,3 @@
 [ <ansi fg="yellow">Lvl:</ansi> <ansi fg="white">{{.Level}}</ansi> ] [ <ansi fg="yellow">XP:</ansi> <ansi fg="white">{{.Exp}}/{{.Tnl}}</ansi> <ansi fg="black-bold">({{pct .Exp .Tnl}}%)</ansi> ] [ <ansi fg="yellow">Training Pts:</ansi> <ansi fg="white">{{.Tp}}</ansi> ] [ <ansi fg="yellow">Stat Pts:</ansi> <ansi fg="white">{{.Sp}}</ansi> ]
-{{ if gt .Sp 0 }}{{ if lt .Level 5 }}<ansi fg="red-bold">TIP:</ansi> <ansi fg="210">Type <ansi fg="command">help status</ansi> to learn about using stat points.</ansi> 
+{{ if gt .Sp 0 }}{{ if lt .Level 5 }}<ansi fg="alert-5">TIP:</ansi> <ansi fg="alert-2">Type <ansi fg="command">help status</ansi> to learn about using stat points.</ansi> 
 {{ end }}{{ end -}}

--- a/_datafiles/templates/character/status.template
+++ b/_datafiles/templates/character/status.template
@@ -15,4 +15,4 @@
  │ <ansi fg="yellow">Armor:  </ansi>{{ printf "%-6s" ( printf "%d" (.Character.GetDefense)) }} {{ if permadeath }}<ansi fg="yellow">Lives: </ansi>{{ printf "%-7d" .Character.ExtraLives }}{{ else }}              {{ end }} │ │ <ansi fg="yellow">Bank: </ansi>{{ printf "%-11s" (numberFormat .Character.Bank) }} │ │ <ansi fg="yellow">Stat Pts:</ansi>  {{ printf "%-7d" .Character.StatPoints }} │
  └───────────────────────────────┘ └───────────────────┘ └────────────────────┘
 {{- if gt .Character.StatPoints 0 }}{{ if lt .Character.Level 5 }}
-                   <ansi fg="red-bold">TIP:</ansi> <ansi fg="210">Type <ansi fg="command">status train</ansi> to spend stat points on improvements.</ansi> {{ end }}{{ end -}}
+                   <ansi fg="alert-5">TIP:</ansi> <ansi fg="alert-2">Type <ansi fg="command">status train</ansi> to spend stat points on improvements.</ansi> {{ end }}{{ end -}}

--- a/_datafiles/templates/descriptions/room.template
+++ b/_datafiles/templates/descriptions/room.template
@@ -1,4 +1,4 @@
-<ansi fg="room-description{{ if or .IsNight .IsDark }}-dark{{ end }}">{{ if ne .TinyMapDescription "" }}{{ .TinyMapDescription }}{{ else }}{{ if .IsBurning }}{{ colorpattern (splitstring .Room.GetDescription 80) "flame" "words" }}{{ else }}{{ splitstring .Room.GetDescription 80 }}{{ end }}{{ end }}</ansi>
+<ansi fg="room-description{{ if or .IsNight .IsDark }}-dark{{ end }}">{{ .Description }}</ansi>
 {{- if ne (len .Room.SkillTraining) 0 }}
 
     <ansi fg="red">┌───────────────────────────────────────────────────────────────────┐</ansi>

--- a/rooms/roommanager.go
+++ b/rooms/roommanager.go
@@ -51,23 +51,23 @@ type ZoneInfo struct {
 }
 
 type RoomTemplateDetails struct {
-	Room               *Room
-	VisiblePlayers     []characters.FormattedName
-	VisibleMobs        []characters.FormattedName
-	VisibleExits       map[string]RoomExit
-	TemporaryExits     map[string]TemporaryRoomExit
-	UserId             int
-	Character          *characters.Character
-	Permission         string
-	RoomSymbol         string
-	RoomLegend         string
-	Nouns              []string
-	TinyMapDescription string
-	IsDark             bool
-	IsNight            bool
-	IsBurning          bool
-	TrackingString     string
-	ExtraMessages      []string
+	Room           *Room
+	VisiblePlayers []characters.FormattedName
+	VisibleMobs    []characters.FormattedName
+	VisibleExits   map[string]RoomExit
+	TemporaryExits map[string]TemporaryRoomExit
+	UserId         int
+	Character      *characters.Character
+	Permission     string
+	RoomSymbol     string
+	RoomLegend     string
+	Nouns          []string
+	Description    string
+	IsDark         bool
+	IsNight        bool
+	IsBurning      bool
+	TrackingString string
+	ExtraMessages  []string
 }
 
 var (

--- a/rooms/rooms.go
+++ b/rooms/rooms.go
@@ -1311,27 +1311,30 @@ func (r *Room) FindContainerByName(containerNameSearch string) string {
 
 func (r *Room) FindNoun(noun string) (foundNoun string, nounDescription string) {
 
-	if desc, ok := r.Nouns[noun]; ok {
-		return noun, desc
-	}
-
-	allSearchNouns := []string{}
-
 	for _, newNoun := range strings.Split(noun, ` `) {
-		allSearchNouns = append(allSearchNouns, newNoun)
+
+		if desc, ok := r.Nouns[newNoun]; ok {
+			return noun, desc
+		}
+
 		// If ended in `s`, strip it and add a new word to the search list
 		if len(newNoun) > 1 && noun[len(newNoun)-1:] == `s` {
-			allSearchNouns = append(allSearchNouns, newNoun[:len(newNoun)-1])
+			if desc, ok := r.Nouns[newNoun[:len(newNoun)-1]]; ok {
+				return newNoun[:len(newNoun)-1], desc
+			}
+		} else if desc, ok := r.Nouns[newNoun+`s`]; ok { // `s`` at end
+			return newNoun + `s`, desc
 		}
-		if len(newNoun) > 2 && noun[len(newNoun)-1:] == `es` {
-			allSearchNouns = append(allSearchNouns, newNoun[:len(newNoun)-2])
-		}
-	}
 
-	for _, testNoun := range allSearchNouns {
-		if desc, ok := r.Nouns[testNoun]; ok {
-			return testNoun, desc
+		// Strip 'es' such as 'torches'
+		if len(newNoun) > 2 && noun[len(newNoun)-2:] == `es` {
+			if desc, ok := r.Nouns[newNoun[:len(newNoun)-2]]; ok {
+				return newNoun[:len(newNoun)-2], desc
+			}
+		} else if desc, ok := r.Nouns[newNoun+`es`]; ok { // `es` at end
+			return newNoun + `es`, desc
 		}
+
 	}
 
 	return ``, ``

--- a/rooms/rooms.go
+++ b/rooms/rooms.go
@@ -1317,8 +1317,12 @@ func (r *Room) FindNoun(noun string) (foundNoun string, nounDescription string) 
 			return noun, desc
 		}
 
+		if len(newNoun) < 2 {
+			continue
+		}
+
 		// If ended in `s`, strip it and add a new word to the search list
-		if len(newNoun) > 1 && noun[len(newNoun)-1:] == `s` {
+		if noun[len(newNoun)-1:] == `s` {
 			if desc, ok := r.Nouns[newNoun[:len(newNoun)-1]]; ok {
 				return newNoun[:len(newNoun)-1], desc
 			}
@@ -1326,13 +1330,35 @@ func (r *Room) FindNoun(noun string) (foundNoun string, nounDescription string) 
 			return newNoun + `s`, desc
 		}
 
+		// Switch ending of `y` to `ies`
+		if noun[len(newNoun)-1:] == `y` {
+			if desc, ok := r.Nouns[newNoun[:len(newNoun)-1]+`ies`]; ok { // `ies` instead of `y` at end
+				return newNoun[:len(newNoun)-1] + `ies`, desc
+			}
+		}
+
+		if len(newNoun) < 3 {
+			continue
+		}
+
 		// Strip 'es' such as 'torches'
-		if len(newNoun) > 2 && noun[len(newNoun)-2:] == `es` {
+		if noun[len(newNoun)-2:] == `es` {
 			if desc, ok := r.Nouns[newNoun[:len(newNoun)-2]]; ok {
 				return newNoun[:len(newNoun)-2], desc
 			}
 		} else if desc, ok := r.Nouns[newNoun+`es`]; ok { // `es` at end
 			return newNoun + `es`, desc
+		}
+
+		if len(newNoun) < 4 {
+			continue
+		}
+
+		// Strip 'es' such as 'torches'
+		if noun[len(newNoun)-3:] == `ies` {
+			if desc, ok := r.Nouns[newNoun[:len(newNoun)-3]+`y`]; ok { // `y` instead of `ies` at end
+				return newNoun[:len(newNoun)-3] + `y`, desc
+			}
 		}
 
 	}

--- a/usercommands/admin.room.go
+++ b/usercommands/admin.room.go
@@ -34,6 +34,46 @@ func Room(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 	var roomId int = 0
 	roomCmd := strings.ToLower(args[0])
 
+	if roomCmd == `noun` || roomCmd == `nouns` {
+
+		// room noun chair "a chair for sitting"
+		if len(args) > 2 {
+			noun := args[1]
+			description := strings.Join(args[2:], ` `)
+
+			if room.Nouns == nil {
+				room.Nouns = map[string]string{}
+			}
+			room.Nouns[noun] = description
+
+			user.SendText(`Noun Added:`)
+			user.SendText(fmt.Sprintf(`<ansi fg="noun">%s</ansi> - %s`, strings.Repeat(` `, 20-len(noun))+noun, description))
+
+			return true, nil
+		}
+
+		// room noun chair
+		if len(args) == 2 || (len(args) == 3 && len(args[2]) == 0) {
+
+			if _, ok := room.Nouns[args[1]]; ok {
+				delete(room.Nouns, args[1])
+				user.SendText(`Noun deleted.`)
+			} else {
+				user.SendText(`Noun not found.`)
+			}
+
+			return true, nil
+		}
+
+		// room noun
+		// room nouns
+		user.SendText(`Room Nouns:`)
+		for noun, description := range room.Nouns {
+			user.SendText(fmt.Sprintf(`<ansi fg="noun">%s</ansi> - %s`, strings.Repeat(` `, 20-len(noun))+noun, description))
+		}
+		return true, nil
+	}
+
 	if roomCmd == "copy" && len(args) >= 3 {
 
 		property := args[1]

--- a/usercommands/get.go
+++ b/usercommands/get.go
@@ -185,9 +185,7 @@ func Get(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 			}
 		}
 
-		if !found {
-			user.SendText(fmt.Sprintf("You don't see a %s around.", rest))
-		} else {
+		if found {
 
 			if matchItem.HasAdjective(`exploding`) {
 				user.SendText(`You can't pick that up, it's about to explode!`)
@@ -242,7 +240,21 @@ func Get(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 			}
 		}
 
+		//
+		// Look for any nouns in the room info
+		//
+		foundNoun, _ := room.FindNoun(rest)
+		if len(foundNoun) > 0 {
+
+			user.SendText(fmt.Sprintf(`You can't get the <ansi fg="noun">%s</ansi>`, foundNoun))
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> is grasping at the air.`, user.Character.Name), user.UserId)
+
+			return true, nil
+		}
+
 	}
+
+	user.SendText(fmt.Sprintf("You don't see a %s around.", rest))
 
 	return true, nil
 }


### PR DESCRIPTION
# Motivation

This adds back in functionality to pepper rooms with "nouns" which are just simple name/description pairs for players to examine in a room.

# Changes
* Admin commands: `room noun <name> <description>`
* Admin users have any obvious nouns in a room description in a different color
* Fixed an issue with colorpatterns applying patterns over existing color tags
* Looking at nouns attempts to do some simple plural/singular matching with `s` and `es` (or without), but not that fancy.
* ansi alias `noun` added

*Example: Noun Highlighting for admins*

<img width="446" alt="image" src="https://github.com/user-attachments/assets/6c448872-59ee-4f86-95a3-fb4e899ac32b">

*Example: Noun list*

<img width="893" alt="image" src="https://github.com/user-attachments/assets/df4e3a02-0288-4ebf-a1d8-9ce092f4d8b5">
