### PR TITLE
Misc fixes

### DIFF
--- a/_datafiles/keywords.yaml
+++ b/_datafiles/keywords.yaml
@@ -160,6 +160,7 @@ help-aliases:
   killstats:        [kills, kd]
   trading:          [haggle]
   pets:             [pet]
+  macros:           [macro]
 # Default aliases for commands
 # For example: inv -> inventory
 # They can be command + argument aliases
@@ -182,7 +183,7 @@ command-aliases:
   attack:           ['a', 'k', 'kill', 'fight']
   get:              ['g', 'take']
   command:          ['cmd']
-  macros:           ['=?']
+  macros:           ['=?', 'macro']
   sneak:            ['sn']
   spells:           ['spellbook']
   backstab:         ['bs']

--- a/_datafiles/keywords.yaml
+++ b/_datafiles/keywords.yaml
@@ -25,6 +25,7 @@ help:
       - death
       - character
       - pets
+      - train
     shops:
       - appraise
       - auction
@@ -76,7 +77,7 @@ help:
       - read
       - say
       - shout
-      - train
+      - broadcast
       - whisper
       - quit
     parties:
@@ -109,6 +110,7 @@ help:
       - search
       - skulduggery
       - sneak
+      - tame
       - track
       - unenchant
       - uncurse

--- a/characters/character.go
+++ b/characters/character.go
@@ -1410,7 +1410,7 @@ func (c *Character) CanDualWield() bool {
 func (c *Character) Validate(recalcPermaBuffs ...bool) error {
 
 	if len(c.Description) == 0 {
-		c.Description = c.Name + " seems thoroughly uninteresting."
+		c.Description = "They seem thoroughly uninteresting."
 	}
 
 	if c.Pet.Exists() {

--- a/usercommands/buy.go
+++ b/usercommands/buy.go
@@ -471,7 +471,10 @@ func tryPurchase(request string, user *users.UserRecord, room *rooms.Room, shopM
 			petInfo.Food.Add()
 		}
 
+		petInfo.Name = petInfo.Type
 		user.Character.Pet = petInfo
+		// make sure new pet buffs get applied
+		user.Character.Validate(true)
 
 		return true
 	}

--- a/usercommands/macros.go
+++ b/usercommands/macros.go
@@ -2,6 +2,7 @@ package usercommands
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/volte6/mud/rooms"
@@ -15,9 +16,16 @@ func Macros(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 		return true, nil
 	}
 
-	user.SendText(`<ansi fg="yellow">Your macros:</ansi>`)
-	for macro, macroCommand := range user.Macros {
+	sortedKeys := make([]string, 0, len(user.Macros))
 
+	for k := range user.Macros {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	user.SendText(`<ansi fg="226">Your macros:</ansi>`)
+	for _, macro := range sortedKeys {
+		macroCommand := user.Macros[macro]
 		user.SendText(``)
 
 		user.SendText(fmt.Sprintf(`  <ansi fg="228">%s</ansi>:`, macro))

--- a/usercommands/macros.go
+++ b/usercommands/macros.go
@@ -2,6 +2,7 @@ package usercommands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/volte6/mud/rooms"
 	"github.com/volte6/mud/users"
@@ -15,12 +16,29 @@ func Macros(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 	}
 
 	user.SendText(`<ansi fg="yellow">Your macros:</ansi>`)
-	for number, macroCommand := range user.Macros {
+	for macro, macroCommand := range user.Macros {
+
 		user.SendText(``)
-		user.SendText(fmt.Sprintf(`<ansi fg="yellow">%s:</ansi>`, number))
-		user.SendText(fmt.Sprintf(`    <ansi fg="command">%s</ansi>`, macroCommand))
+
+		user.SendText(fmt.Sprintf(`  <ansi fg="228">%s</ansi>:`, macro))
+
+		commandParts := strings.Split(macroCommand, `;`)
+
+		for i, cmd := range commandParts {
+
+			cmdParts := strings.Split(cmd, ` `)
+			cmdAlone := cmdParts[0]
+			cmdRest := ``
+			if len(cmdParts) > 1 {
+				cmdRest = strings.Join(cmdParts[1:], ` `)
+			}
+
+			user.SendText(fmt.Sprintf(`      %s) <ansi fg="command">%s</ansi> %s`, string(97+i), cmdAlone, cmdRest))
+		}
 	}
 	user.SendText(``)
+	user.SendText(`To use a macro, type <ansi fg="command">={num}</ansi>.`)
+	user.SendText(`Some terminals support pressing the associated F-Key (<ansi fg="228">F1</ansi>, <ansi fg="228">F2</ansi>, etc.)`)
 
 	return true, nil
 }

--- a/webclient/webclient.html
+++ b/webclient/webclient.html
@@ -777,6 +777,13 @@ Type your commands below.
 
         textInput.addEventListener('keydown', function(event) {
             
+            // Macro support
+            if ( event.key.substring(0, 1) == "F" && event.key.length == 2 ) {
+                macroNum = event.key.substring(1, 2)
+                SendData("="+macroNum)
+                return
+            }
+
             if (event.key == 'ArrowUp' || event.key == 'ArrowDown') {
                 if ( event.key == 'ArrowUp' ) {
                     historyPosition += 1;

--- a/world.go
+++ b/world.go
@@ -698,7 +698,7 @@ func (w *World) processInput(userId int, inputText string) {
 		if user.Macros != nil && len(inputText) == 2 {
 			if macro, ok := user.Macros[inputText]; ok {
 				handled = true
-				for _, newCmd := range strings.Split(macro, `;`) {
+				for waitTime, newCmd := range strings.Split(macro, `;`) {
 					if newCmd == `` {
 						continue
 					}
@@ -706,6 +706,7 @@ func (w *World) processInput(userId int, inputText string) {
 					events.AddToQueue(events.Input{
 						UserId:    userId,
 						InputText: newCmd,
+						WaitTurns: waitTime,
 					})
 
 				}


### PR DESCRIPTION
# Motivation

This addresses some bugs and quirks found during live testing.

# Changes
* `broadcast`/`train`/`tame` commands added to help list
* Default character description no longer includes a name, avoiding using the account name instead of (possibly unset) character name.
* Fixed a bug with macros causing a crash
* `macro` aliased to `macros` for both command and helpfiles.
* Improved macro display, brake down into individual commands and display (see example below)
* Added some restrictions to macros:
  * limit to 15 commands
  * commands cannot be empty
* Added function key (`F1` to `=1`, `F2` to `=2` etc.) support to web client.

Macro display (`macro` command):

<img width="803" alt="image" src="https://github.com/user-attachments/assets/c47159e2-77a7-4024-bcaa-dbf25e2cfddb">
