### PR TITLE
Adding "StartRoom" config override. Fixing bump command.

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -148,6 +148,11 @@ ZombieSeconds: 30
 #   How many rounds of meditation a player must complete before they are
 #   logged out. If interrupted, they must start over.
 LogoutRounds: 3
+# - StartRoom -
+#   This is the default starting room for the game. It only matters when there
+#   is code that explicitely tries to send the player to the "starting room"
+#   The default of 1 is Town Square in Frostfang
+StartRoom: 1
 # - TutorialStartRooms - 
 #   RoomIds players will be put in when starting the game/tutorial
 #   RoomIds 900-999 are reserved for Tutorial rooms.

--- a/_datafiles/mobs/frostfang/scripts/38-player_guide.js
+++ b/_datafiles/mobs/frostfang/scripts/38-player_guide.js
@@ -153,7 +153,7 @@ function onAsk(mob, room, eventDetails) {
         mob.Command(`sayto @`+String(eventDetails.sourceId)+` back to <ansi fg="room-title">Town Square</ansi>? Sure thing, lets go!`);
         mob.Command(`emote whispers a soft incantation and summons a ` + UtilApplyColorPattern(`glowing portal`, `cyan`) + `.`);
 
-        room.AddTemporaryExit(`glowing portal`, `:cyan`, 1, 3);
+        room.AddTemporaryExit(`glowing portal`, `:cyan`, 0, 3); // roomId zero is start room alias
 
         return true;
     }

--- a/_datafiles/rooms/tutorial/903.js
+++ b/_datafiles/rooms/tutorial/903.js
@@ -62,7 +62,7 @@ function onCommand(cmd, rest, user, room) {
             exits = room.GetExits();
             if ( !exits['portal'] ) {
                 teacherMob.Command('emote glows intensely, and a ' + UtilApplyColorPattern('swirling portal', 'pink') + ' appears!');
-                room.AddTemporaryExit('swirling portal', ':pink', 1, 9000);
+                room.AddTemporaryExit('swirling portal', ':pink', 0, 9000); // RoomId 0 is an alias for start room
             }
 
             teacherMob.Command('say Enter the portal when you are ready.');

--- a/_datafiles/rooms/tutorial/993.js
+++ b/_datafiles/rooms/tutorial/993.js
@@ -62,7 +62,7 @@ function onCommand(cmd, rest, user, room) {
             exits = room.GetExits();
             if ( !exits['portal'] ) {
                 teacherMob.Command('emote glows intensely, and a ' + UtilApplyColorPattern('swirling portal', 'pink') + ' appears!');
-                room.AddTemporaryExit('swirling portal', ':pink', 1, 9000);
+                room.AddTemporaryExit('swirling portal', ':pink', 0, 9000); // RoomId 0 is an alias for start room
             }
 
             teacherMob.Command('say Enter the portal when you are ready.');

--- a/_datafiles/templates/help/skulduggery.template
+++ b/_datafiles/templates/help/skulduggery.template
@@ -7,7 +7,7 @@ Each skill is improved by your stats and level as well.
 <ansi fg="yellow">Usage: </ansi>
 
 (Lvl 1) <ansi fg="skill">sneak [direction/exit]</ansi> Remain hidden for a period of time, even when moving between areas.
-(Lvl 2) <ansi fg="skill">bump</ansi> Bump into a player or NPC, causing a fraction of their coins to drop to the ground.
+(Lvl 2) <ansi fg="skill">bump [enemy]</ansi> Bump into a player or NPC, causing a fraction of their coins to drop to the ground.
 (Lvl 3) <ansi fg="skill">backstab [enemy]</ansi> Guarenteed critical on successful attack.
 (Lvl 4) <ansi fg="skill">pickpocket [enemy]</ansi> Gain ability to steal from players and NPC's while hidden.
 

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -71,6 +71,7 @@ type Config struct {
 	TimeoutMods        ConfigBool        `yaml:"TimeoutMods"`        // Whether to kick admin/mods when idle too long.
 	ZombieSeconds      ConfigInt         `yaml:"ZombieSeconds"`      // How many seconds a player will be a zombie allowing them to reconnect.
 	LogoutRounds       ConfigInt         `yaml:"LogoutRounds"`       // How many rounds of uninterrupted meditation must be completed to log out.
+	StartRoom          ConfigInt         `yaml:"StartRoom"`          // Default starting room.
 	TutorialStartRooms ConfigSliceString `yaml:"TutorialStartRooms"` // List of all rooms that can be used to begin the tutorial process
 
 	// Perma-death related configs

--- a/mobcommands/go.go
+++ b/mobcommands/go.go
@@ -75,7 +75,7 @@ func Go(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	}
 
-	if goRoomId > 0 {
+	if exitName != `` {
 
 		// Load current room details
 		destRoom := rooms.LoadRoom(goRoomId)

--- a/mobcommands/look.go
+++ b/mobcommands/look.go
@@ -54,7 +54,7 @@ func Look(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 	// Check room exits
 	//
 	exitName, lookRoomId := room.FindExitByName(lookAt)
-	if lookRoomId > 0 {
+	if exitName != `` {
 
 		exitInfo := room.Exits[exitName]
 		if exitInfo.Lock.IsLocked() {
@@ -65,12 +65,9 @@ func Look(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 			room.SendText(fmt.Sprintf(`<ansi fg="mobname">%s</ansi> peers toward the %s.`, mob.Character.Name, exitName))
 		}
 
-		if lookRoomId > 0 {
+		lookRoom(mob, lookRoomId, secretLook || isSneaking)
 
-			lookRoom(mob, lookRoomId, secretLook || isSneaking)
-
-			return true, nil
-		}
+		return true, nil
 	}
 
 	//

--- a/mobcommands/portal.go
+++ b/mobcommands/portal.go
@@ -43,7 +43,7 @@ func Portal(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 		// Only interest in rooms where players haven't visited in a while and have at least 1
 		mostItemRoomId, qty := rooms.GetRoomWithMostItems(bool(config.LootGoblinIncludeRecentRooms), int(config.LootGoblinMinimumItems), int(config.LootGoblinMinimumGold))
-		if portalTargetRoomId == 0 && qty == 0 { // could't find any
+		if qty == 0 { // could't find any
 			// No more rooms with items? Our job is done i guess.
 
 			mob.Command(`portal home;drop all`)

--- a/mobcommands/shoot.go
+++ b/mobcommands/shoot.go
@@ -36,7 +36,7 @@ func Shoot(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 	// Only shooting weapons can target adjacent rooms
 	// "attack goblin east"
 	exitName, attackRoomId := room.FindExitByName(direction)
-	if attackRoomId > 0 {
+	if exitName != `` {
 
 		exitInfo := room.Exits[exitName]
 		if exitInfo.Lock.IsLocked() {
@@ -46,9 +46,7 @@ func Shoot(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		if adjacentRoom := rooms.LoadRoom(attackRoomId); adjacentRoom != nil {
 			attackPlayerId, attackMobInstanceId = adjacentRoom.FindByName(strings.Join(args, ` `))
 		}
-	}
-
-	if attackRoomId == 0 {
+	} else {
 		return true, nil
 	}
 

--- a/mobcommands/throw.go
+++ b/mobcommands/throw.go
@@ -33,17 +33,17 @@ func Throw(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 	exitName, throwRoomId := room.FindExitByName(throwWhere)
 
 	// If nothing found, consider directional aliases
-	if throwRoomId == 0 {
+	if exitName == `` {
 
 		if alias := keywords.TryDirectionAlias(throwWhere); alias != throwWhere {
 			exitName, throwRoomId = room.FindExitByName(alias)
-			if throwRoomId != 0 {
+			if exitName != `` {
 				throwWhere = alias
 			}
 		}
 	}
 
-	if throwRoomId > 0 {
+	if exitName != `` {
 
 		exitInfo := room.Exits[exitName]
 		if exitInfo.Lock.IsLocked() {

--- a/mobcommands/wander.go
+++ b/mobcommands/wander.go
@@ -54,7 +54,7 @@ func Wander(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		}
 	}
 
-	if exitName, roomId := room.GetRandomExit(); roomId > 0 {
+	if exitName, roomId := room.GetRandomExit(); exitName != `` {
 		if r := rooms.LoadRoom(roomId); r != nil {
 			if !restrictZone || r.Zone == mob.Character.Zone {
 

--- a/scripting/docs/FUNCTIONS_ACTORS.md
+++ b/scripting/docs/FUNCTIONS_ACTORS.md
@@ -175,6 +175,8 @@ Sets permanent data for the ActorObject.
 
 _Note: This miscellaneous data is attached to the character data, not the user data. If the user changes characters, it will not follow._
 
+_Note: There is a special key: `StartRoom` that will override the Start RoomId for the character if set._
+
 |  Argument | Explanation |
 | --- | --- |
 | key | A unique identifier for the data. |

--- a/usercommands/admin.room.go
+++ b/usercommands/admin.room.go
@@ -122,13 +122,14 @@ func Room(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 		direction := strings.ToLower(args[1])
 		roomId = 0
+		var numError error = nil
 
 		if len(args) > 2 {
-			roomId, _ = strconv.Atoi(args[2])
+			roomId, numError = strconv.Atoi(args[2])
 		}
 
 		// Will be erasing it.
-		if roomId == 0 {
+		if numError != nil || len(args) < 3 { // If a bad room number or NO room number supplied, delete
 			if _, ok := room.Exits[direction]; !ok {
 				user.SendText(fmt.Sprintf("Exit %s does not exist.", direction))
 				return handled, nil
@@ -233,6 +234,7 @@ func Room(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 	} else {
 
 		var gotoRoomId int = 0
+		var numError error = nil
 
 		if deltaD, ok := rooms.DirectionDeltas[roomCmd]; ok {
 
@@ -266,10 +268,10 @@ func Room(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 			//dirDelta.Dy
 		} else {
 			// move to a new room
-			gotoRoomId, _ = strconv.Atoi(args[0])
+			gotoRoomId, numError = strconv.Atoi(args[0])
 		}
 
-		if gotoRoomId != 0 {
+		if numError == nil {
 
 			previousRoomId := user.Character.RoomId
 

--- a/usercommands/go.go
+++ b/usercommands/go.go
@@ -33,7 +33,7 @@ func Go(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	exitName, goRoomId := room.FindExitByName(rest)
 
-	if goRoomId > 0 || exitName != `` {
+	if exitName != `` {
 
 		if user.Character.IsDisabled() {
 			user.SendText("You are unable to do that while downed.")

--- a/usercommands/lock.go
+++ b/usercommands/lock.go
@@ -20,7 +20,7 @@ func Lock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 	}
 
 	containerName := room.FindContainerByName(args[0])
-	exitName, exitRoomId := room.FindExitByName(args[0])
+	exitName, _ := room.FindExitByName(args[0])
 
 	if containerName != `` {
 
@@ -68,7 +68,7 @@ func Lock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 		return true, nil
 
-	} else if exitRoomId > 0 {
+	} else if exitName != `` {
 
 		exitInfo := room.Exits[exitName]
 

--- a/usercommands/look.go
+++ b/usercommands/look.go
@@ -206,17 +206,17 @@ func Look(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 	exitName, lookRoomId := room.FindExitByName(lookAt)
 
 	// If nothing found, consider directional aliases
-	if lookRoomId == 0 {
+	if exitName == `` {
 
 		if alias := keywords.TryDirectionAlias(lookAt); alias != lookAt {
 			exitName, lookRoomId = room.FindExitByName(alias)
-			if lookRoomId != 0 {
+			if exitName != `` {
 				lookAt = alias
 			}
 		}
 	}
 
-	if lookRoomId > 0 {
+	if exitName != `` {
 
 		if visibility < 2 {
 
@@ -241,12 +241,10 @@ func Look(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> peers toward the %s.`, user.Character.Name, exitName), user.UserId)
 		}
 
-		if lookRoomId > 0 {
+		lookRoom(user, lookRoomId, secretLook || isSneaking)
 
-			lookRoom(user, lookRoomId, secretLook || isSneaking)
+		return true, nil
 
-			return true, nil
-		}
 	}
 
 	//

--- a/usercommands/picklock.go
+++ b/usercommands/picklock.go
@@ -38,7 +38,7 @@ func Picklock(rest string, user *users.UserRecord, room *rooms.Room) (bool, erro
 	lockStrength := 0
 
 	containerName := room.FindContainerByName(args[0])
-	exitName, exitRoomId := room.FindExitByName(args[0])
+	exitName, _ := room.FindExitByName(args[0])
 
 	if containerName != `` {
 
@@ -58,7 +58,7 @@ func Picklock(rest string, user *users.UserRecord, room *rooms.Room) (bool, erro
 		lockStrength = int(container.Lock.Difficulty)
 		lockId = fmt.Sprintf(`%d-%s`, room.RoomId, containerName)
 
-	} else if exitRoomId > 0 {
+	} else if exitName != `` {
 
 		// get the first entry int he slice and shorten the slice
 		args = args[1:]

--- a/usercommands/shoot.go
+++ b/usercommands/shoot.go
@@ -39,7 +39,7 @@ func Shoot(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 	// Only shooting weapons can target adjacent rooms
 	// "attack goblin east"
 	exitName, attackRoomId := room.FindExitByName(direction)
-	if attackRoomId > 0 {
+	if exitName != `` {
 
 		exitInfo := room.Exits[exitName]
 		if exitInfo.Lock.IsLocked() {
@@ -50,9 +50,7 @@ func Shoot(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 		if adjacentRoom := rooms.LoadRoom(attackRoomId); adjacentRoom != nil {
 			attackPlayerId, attackMobInstanceId = adjacentRoom.FindByName(strings.Join(args, ` `))
 		}
-	}
-
-	if attackRoomId == 0 {
+	} else {
 		user.SendText(`Could not find where you wanted to shoot`)
 		return true, nil
 	}

--- a/usercommands/skill.brawling.throw.go
+++ b/usercommands/skill.brawling.throw.go
@@ -145,16 +145,16 @@ func Throw(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 		exitName, throwRoomId := room.FindExitByName(throwWhere)
 
 		// If nothing found, consider directional aliases
-		if throwRoomId == 0 {
+		if exitName == `` {
 			if alias := keywords.TryDirectionAlias(throwWhere); alias != throwWhere {
 				exitName, throwRoomId = room.FindExitByName(alias)
-				if throwRoomId != 0 {
+				if exitName != `` {
 					throwWhere = alias
 				}
 			}
 		}
 
-		if throwRoomId > 0 {
+		if exitName != `` {
 
 			exitInfo := room.Exits[exitName]
 			if exitInfo.Lock.IsLocked() {

--- a/usercommands/skill.portal.go
+++ b/usercommands/skill.portal.go
@@ -37,7 +37,7 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 	}
 
 	// Establish the default portal location
-	portalTargetRoomId := 1 // Defaults to Town Square of Frostfang
+	portalTargetRoomId := rooms.StartRoomIdAlias // Defaults to Start Room
 
 	if skillLevel >= 2 { // Defaults to root of current zone
 		portalTargetRoomId, _ = rooms.GetZoneRoot(user.Character.Zone)
@@ -56,11 +56,6 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 	}
 
 	portalLifeInSeconds := 30 + (user.Character.Stats.Mysticism.ValueAdj * 10) // 0 mysticism = 30 seconds, 100 mysticism = 1030 seconds
-
-	// Make sure we haven't borked anything
-	if portalTargetRoomId < 1 {
-		portalTargetRoomId = 1
-	}
 
 	// If no argument supplied, is a direct teleport.
 	if rest == "" {

--- a/usercommands/skill.skulduggery.bump.go
+++ b/usercommands/skill.skulduggery.bump.go
@@ -36,6 +36,11 @@ func Bump(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 		return true, nil
 	}
 
+	if len(rest) == 0 {
+		user.SendText("Who do you wanna bump?")
+		return true, nil
+	}
+
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
 	pickPlayerId, pickMobInstanceId := room.FindByName(args[0])

--- a/usercommands/unlock.go
+++ b/usercommands/unlock.go
@@ -20,7 +20,7 @@ func Unlock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 	}
 
 	containerName := room.FindContainerByName(args[0])
-	exitName, exitRoomId := room.FindExitByName(args[0])
+	exitName, _ := room.FindExitByName(args[0])
 
 	if containerName != `` {
 
@@ -68,7 +68,7 @@ func Unlock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 		return true, nil
 
-	} else if exitRoomId > 0 {
+	} else if exitName != `` {
 
 		exitInfo := room.Exits[exitName]
 

--- a/world.roundtick.go
+++ b/world.roundtick.go
@@ -528,7 +528,7 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 			// Success!
 			exitName, exitRoomId := uRoom.GetRandomExit()
 
-			if exitRoomId == 0 {
+			if exitName == `` {
 				user.SendText(`You can't find an exit!`)
 				continue
 			}
@@ -1616,7 +1616,7 @@ func (w *World) handleShadowRealm(roundNumber uint64) {
 			}
 
 			tmpExit := rooms.TemporaryRoomExit{
-				RoomId:  1,
+				RoomId:  rooms.StartRoomIdAlias,
 				Title:   colorpatterns.ApplyColorPattern(`shimmering portal`, `cyan`),
 				UserId:  0,
 				Expires: time.Now().Add(time.Second * 10),


### PR DESCRIPTION
# Motivation

This is to facilitate custom start rooms other than town square, especially as players build out their own worlds.
It also contains a fix for the `bump` command that was causing crashes.

# Changes
* `StartRoom` added to `config.yaml`
* Updated references to sending players to room 1 (town square) to use `0` (zero) as an alias to "StartRoom"
* Lots of code changes that disregarded room 0, now allow it.
* Fixed `bump` when no target specified would crash.
* Updated `bump` helpfile to indicate how to use it.
