### PR TITLE
Put gold and items into containers

### DIFF
--- a/_datafiles/keywords.yaml
+++ b/_datafiles/keywords.yaml
@@ -81,6 +81,7 @@ help:
       - trash
       - use
       - read
+      - put
     general:
       - online
       - quit
@@ -207,6 +208,7 @@ command-aliases:
   unlock:           ['open']
   buy:              ['hire']
   trash:            ['junk']
+  put:              ['place']
   'party chat':     ['pchat', 'psay']
   'bank deposit':   ['deposit']
   'bank withdraw':  ['withdraw']

--- a/_datafiles/templates/help/put.template
+++ b/_datafiles/templates/help/put.template
@@ -1,0 +1,11 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">put</ansi>
+
+The <ansi fg="command">put</ansi> command puts objects into containers.
+
+<ansi fg="yellow">Usage: </ansi>
+
+  <ansi fg="command">put stick in chest</ansi>
+  This would put a stick you hold into the chest in the room.
+  <ansi fg="command">put 10 gold into chest</ansi>
+  This would put 10 gold into the chest.
+

--- a/rooms/container.go
+++ b/rooms/container.go
@@ -3,9 +3,9 @@ package rooms
 import "github.com/volte6/gomud/items"
 
 type Container struct {
-	Lock  GameLock     `yaml:"lock,omitempty"` // 0 - no lock. greater than zero = difficulty to unlock.
-	Items []items.Item `yaml:"-"`              // Don't save contents, let room prep handle. What is found inside of the chest.
-	Gold  int          `yaml:"-"`              // Don't save contents, let room prep handle. How much gold is found inside of the chest.
+	Lock  GameLock     `yaml:"lock,omitempty"`  // 0 - no lock. greater than zero = difficulty to unlock.
+	Items []items.Item `yaml:"items,omitempty"` // Save contents now, since players can put new items in there
+	Gold  int          `yaml:"gold,omitempty"`  // Save contents now, since players can put new items in there
 }
 
 func (c Container) HasLock() bool {

--- a/usercommands/look.go
+++ b/usercommands/look.go
@@ -173,7 +173,7 @@ func Look(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 		if container.Lock.IsLocked() {
 			user.SendText(``)
-			user.SendText(`The chest is locked.`)
+			user.SendText(fmt.Sprintf(`The <ansi fg="container">%s</ansi> is locked.`, containerName))
 			user.SendText(``)
 			return true, nil
 		}

--- a/usercommands/put.go
+++ b/usercommands/put.go
@@ -1,0 +1,126 @@
+package usercommands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/volte6/gomud/items"
+	"github.com/volte6/gomud/rooms"
+	"github.com/volte6/gomud/users"
+	"github.com/volte6/gomud/util"
+)
+
+func Put(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+
+	args := util.SplitButRespectQuotes(strings.ToLower(rest))
+
+	if len(args) < 2 {
+		user.SendText("Place what where?")
+		return true, nil
+	}
+
+	containerName := ``
+	nameSearch := ``
+	for i := len(args) - 1; i >= 1; i-- {
+		if len(nameSearch) > 0 {
+			nameSearch = ` ` + nameSearch
+		}
+		nameSearch = args[i] + nameSearch
+
+		containerName = room.FindContainerByName(nameSearch)
+		if containerName != `` {
+			args = args[:i]
+			break
+		}
+	}
+
+	if containerName == `` {
+		user.SendText(`No container found by that name`)
+		return true, nil
+	}
+
+	container := room.Containers[containerName]
+
+	if container.Lock.IsLocked() {
+		user.SendText(``)
+		user.SendText(fmt.Sprintf(`The <ansi fg="container">%s</ansi> is locked.`, containerName))
+		user.SendText(``)
+		return true, nil
+	}
+
+	if len(args) < 1 {
+		user.SendText("Place what where?")
+		return true, nil
+	}
+
+	var item items.Item
+	var itemFound bool
+	goldAmt := 0
+
+	if len(args) >= 2 && args[1] == `gold` {
+
+		g, _ := strconv.ParseInt(args[0], 10, 32)
+		goldAmt = int(g)
+		if goldAmt < 0 {
+			goldAmt = -1 * goldAmt
+		}
+
+	} else {
+
+		item, itemFound = user.Character.FindInBackpack(strings.Join(args, ` `))
+		if !itemFound && len(args) > 1 {
+			item, itemFound = user.Character.FindInBackpack(args[0])
+		}
+
+	}
+
+	if !itemFound && goldAmt == 0 {
+		user.SendText(`You don't seem to be carrying that.`)
+		return true, nil
+	}
+
+	if goldAmt > user.Character.Gold {
+		user.SendText(`You don't have that much gold.`)
+		return true, nil
+	}
+
+	if goldAmt > 0 {
+		user.Character.Gold -= goldAmt
+		container.Gold += goldAmt
+		user.SendText(fmt.Sprintf(`You place <ansi fg="gold">%d gold</ansi> into the <ansi fg="container">%s</ansi>`, goldAmt, containerName))
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> places some <ansi fg="gold">gold</ansi> into the <ansi fg="container">%s</ansi>`, user.Character.Name, containerName), user.UserId)
+	}
+
+	if itemFound {
+		container.AddItem(item)
+		user.Character.RemoveItem(item)
+
+		user.SendText(fmt.Sprintf(`You place your <ansi fg="itemname">%s</ansi> into the <ansi fg="container">%s</ansi>`, item.DisplayName(), containerName))
+		room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> places their <ansi fg="itemname">%s</ansi> into the <ansi fg="container">%s</ansi>`, user.Character.Name, item.DisplayName(), containerName), user.UserId)
+
+		// current hard limit of 10 max items.
+		if len(container.Items) > 10 {
+
+			randItemToRemove := util.Rand(len(container.Items))
+			oopsItem := container.Items[randItemToRemove]
+
+			// get all items that spawn in chests
+			for _, spn := range room.SpawnInfo {
+				if spn.Container == containerName && oopsItem.ItemId == spn.ItemId {
+					// Don't let this one pop out
+					oopsItem = item
+					break
+				}
+			}
+
+			container.RemoveItem(oopsItem)
+			room.SendText(fmt.Sprintf(`The <ansi fg="container">%s</ansi> is too full and a <ansi fg="itemname">%s</ansi> falls out and onto the floor.`, containerName, oopsItem.DisplayName()))
+			room.AddItem(oopsItem, false)
+		}
+	}
+
+	room.Containers[containerName] = container
+
+	return true, nil
+}

--- a/usercommands/storage.go
+++ b/usercommands/storage.go
@@ -17,7 +17,18 @@ import (
 func Storage(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if !room.IsStorage {
+
 		user.SendText(`You are not at a storage location.` + term.CRLFStr)
+
+		if len(room.Containers) > 0 {
+			cName := ``
+			for k, _ := range room.Containers {
+				cName = k
+				break
+			}
+			user.SendText(fmt.Sprintf(`Maybe you meant to use the <ansi fg="command">put</ansi> command to <ansi fg="command">put</ansi> something into the <ansi fg="container">%s</ansi>?`, cName) + term.CRLFStr)
+		}
+
 		return true, nil
 	}
 

--- a/usercommands/usercommands.go
+++ b/usercommands/usercommands.go
@@ -98,6 +98,7 @@ var (
 		`portal`:      {Portal, false, false},
 		`pray`:        {Pray, false, false},
 		`print`:       {Print, true, false},
+		`put`:         {Put, false, false},
 		`quests`:      {Quests, true, false},
 		`quit`:        {Quit, true, false},
 		`questtoken`:  {QuestToken, false, true}, // Admin only


### PR DESCRIPTION
# Motivation

While players can take things out of containers, they cannot put things into containers. This fixes that.

# Changes
* Added `put` command (alias `place`)
* If a player uses the `store`/`storage` command outside of a storage are and a container is present, recommends using `put`
* Now saving chest contents since there could be unexpected items placed into them.
* Minor fix to some messaging.