### PR TITLE
Experience grant centralizing

### DIFF
--- a/_datafiles/templates/admincommands/help/command.grant.template
+++ b/_datafiles/templates/admincommands/help/command.grant.template
@@ -1,0 +1,7 @@
+The <ansi fg="command">grant</ansi> command can be used in the following ways:
+
+<ansi fg="command">grant [amount] experience</ansi> - e.g. <ansi fg="command">grant 1000 experience</ansi>
+Grant experience points to yourself
+
+<ansi fg="command">grant [target] [amount] experience</ansi> - e.g. <ansi fg="command">grant james 1000 experience</ansi>
+Grant experience points to a user

--- a/internal/mobcommands/suicide.go
+++ b/internal/mobcommands/suicide.go
@@ -95,7 +95,6 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 		attackerCt := len(mob.DamageTaken)
 
-		xpMsg := `You gained <ansi fg="experience">%d experience points</ansi>%s!`
 		for uId, _ := range mob.DamageTaken {
 			if user := users.GetByUserId(uId); user != nil {
 
@@ -128,16 +127,7 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 					slog.Info("XP Calculation", "MobLevel", mob.Character.Level, "XPBase", mobXP, "xpVal", xpVal, "xpVariation", xpVariation, "xpScaler", xpScaler, "finalXPVal", finalXPVal)
 
-					grantXP, xpScale := user.Character.GrantXP(finalXPVal)
-
-					xpMsgExtra := ``
-					if xpScale != 100 {
-						xpMsgExtra = fmt.Sprintf(` <ansi fg="yellow">(%d%% scale)</ansi>`, xpScale)
-					}
-
-					user.SendText(
-						fmt.Sprintf(xpMsg, grantXP, xpMsgExtra),
-					)
+					user.GrantXP(finalXPVal, `combat`)
 
 					// Apply alignment changes
 					alignmentBefore := user.Character.AlignmentName()
@@ -201,7 +191,6 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	if len(partyTracker) > 0 {
 
-		xpMsg := `You gained <ansi fg="yellow-bold">%d experience points</ansi>%s!`
 		for leaderId, xp := range partyTracker {
 			if p := parties.Get(leaderId); p != nil {
 
@@ -218,16 +207,7 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 							user.Character.KD.AddMobKill(int(mob.MobId))
 						}
 
-						grantXP, xpScale := user.Character.GrantXP(xpSplit)
-
-						xpMsgExtra := ``
-						if xpScale != 100 {
-							xpMsgExtra = fmt.Sprintf(` <ansi fg="yellow">(%d%% scale)</ansi>`, xpScale)
-						}
-
-						user.SendText(
-							fmt.Sprintf(xpMsg, grantXP, xpMsgExtra),
-						)
+						user.GrantXP(xpSplit, `combat`)
 
 						// Apply alignment changes
 						alignmentBefore := user.Character.AlignmentName()

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -613,6 +613,13 @@ func (a ScriptActor) GetPet() *pets.Pet {
 	return nil
 }
 
+func (a ScriptActor) GrantXP(xpAmt int, reason string) {
+	if a.mobInstanceId > 0 {
+		return
+	}
+	a.userRecord.GrantXP(xpAmt, reason)
+}
+
 // ////////////////////////////////////////////////////////
 //
 // Functions only really useful for mobs

--- a/internal/scripting/docs/FUNCTIONS_ACTORS.md
+++ b/internal/scripting/docs/FUNCTIONS_ACTORS.md
@@ -74,6 +74,9 @@ ActorObjects are the basic object that represents Users and NPCs
   - [ActorObject.ShorthandId() string](#actorobjectshorthandid-string)
   - [ActorObject.WebClientModalOpen(name string, value string)](#actorobjectwebclientmodalopenname-string-value-string)
   - [ActorObject.WebClientModalClose(name string)](#actorobjectwebclientmodalclosename-string)
+  - [ActorObject.Uncurse()](#actorobjectuncurse)
+  - [ActorObject.GetPet()](#actorobjectgetpet)
+  - [ActorObject.GrantXP(xpAmt int, reason string)](#actorobjectgrantxpxpamt-int-reason-string)
   - [ActorObject.GetLastInputRound() int](#actorobjectgetlastinputround-int)
   - [ActorObject.GetTameMastery() Object](#actorobjectgettamemastery-object)
   - [ActorObject.SetTameMastery(mobId int, newSkillLevel int)](#actorobjectsettamemasterymobid-int-newskilllevel-int)
@@ -511,6 +514,22 @@ Closes a modal if one by the name exists, IF the user is on a webclient
 |  Argument | Explanation |
 | --- | --- |
 | name | title of the modal to close |
+
+
+
+## [ActorObject.Uncurse()](/internal/scripting/actor_func.go)
+Uncurses any objects the target has equipped
+
+## [ActorObject.GetPet()](/internal/scripting/actor_func.go)
+Returns the pet object for the actor, or null
+
+## [ActorObject.GrantXP(xpAmt int, reason string)](/internal/scripting/actor_func.go)
+Gives experience points to the actor
+
+|  Argument | Explanation |
+| --- | --- |
+| xpAmt | How much experience to grant |
+| reason | Short reasons such as "combat", "trash cleanup" |
 
 ## [ActorObject.GetLastInputRound() int](/internal/scripting/actor_func.go)
 Returns the last round number the user input anything at all

--- a/internal/usercommands/admin.grant.go
+++ b/internal/usercommands/admin.grant.go
@@ -1,0 +1,67 @@
+package usercommands
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/volte6/gomud/internal/rooms"
+	"github.com/volte6/gomud/internal/util"
+
+	"github.com/volte6/gomud/internal/templates"
+	"github.com/volte6/gomud/internal/users"
+)
+
+func Grant(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+
+	if rest == "" {
+		infoOutput, _ := templates.Process("admincommands/help/command.grant", nil)
+		user.SendText(infoOutput)
+		return true, nil
+	}
+
+	// args should look like one of the following:
+	// [?target] 1000 experience - grant experience points to target, or self if unspecified target
+	args := util.SplitButRespectQuotes(rest)
+
+	targetUserId := 0
+	targetMobInstanceId := 0
+
+	lastWord := args[len(args)-1]
+
+	if len(args) >= 2 && len(lastWord) >= 3 && lastWord[0:3] == `exp` || lastWord == `xp` {
+
+		expAmt := 0
+
+		if len(args) > 2 {
+
+			targetUserId, targetMobInstanceId = room.FindByName(args[0])
+			expAmt, _ = strconv.Atoi(args[1])
+
+		} else {
+			targetUserId = user.UserId
+			expAmt, _ = strconv.Atoi(args[0])
+		}
+
+		if targetUserId > 0 {
+
+			if u := users.GetByUserId(targetUserId); u != nil {
+				u.GrantXP(expAmt, `admin grant`)
+				user.SendText(fmt.Sprintf(`Granted <ansi fg="experience">%d experience</ansi> to <ansi fg="username">%s</ansi>.`, expAmt, u.Character.Name))
+				return true, nil
+			}
+
+		} else if targetMobInstanceId > 0 {
+			user.SendText(`Cannot grant experience to mobs.`)
+			return true, nil
+		}
+
+		user.SendText(`Target not found.`)
+		return true, errors.New(`target not found`)
+
+	}
+
+	user.SendText(`Invalid command.`)
+
+	return false, errors.New(`unrecognized command`)
+}

--- a/internal/usercommands/trash.go
+++ b/internal/usercommands/trash.go
@@ -33,15 +33,11 @@ func Trash(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 
 		iSpec := matchItem.GetSpec()
 
-		grantXP, xpScale := user.Character.GrantXP(int(float64(iSpec.Value) / 10))
-
-		xpMsgExtra := ``
-		if xpScale != 100 {
-			xpMsgExtra = fmt.Sprintf(` <ansi fg="yellow">(%d%% scale)</ansi>`, xpScale)
+		xpGrant := int(float64(iSpec.Value) / 10)
+		if xpGrant < 1 {
+			xpGrant = 1
 		}
-
-		user.SendText(
-			fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi>%s!`, grantXP, xpMsgExtra))
+		user.GrantXP(xpGrant, `trash cleanup`)
 
 		// Trigger lost event
 		scripting.TryItemScriptEvent(`onLost`, matchItem, user.UserId)

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -69,6 +69,7 @@ var (
 		`get`:         {Get, false, false},
 		`give`:        {Give, false, false},
 		`go`:          {Go, false, false},
+		`grant`:       {Grant, true, true}, // Admin only
 		`help`:        {Help, true, false},
 		`keyring`:     {KeyRing, true, false},
 		`killstats`:   {Killstats, true, false},

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -121,6 +121,21 @@ func (u *UserRecord) HasShop() bool {
 	return len(u.Character.Shop) > 0
 }
 
+// Grants experience to the user and notifies them
+// Additionally accepts `source` as a short identifier of the XP source
+// Example source: "combat", "quest progress", "trash cleanup", "exploration"
+func (u *UserRecord) GrantXP(amt int, source string) {
+
+	grantXP, xpScale := u.Character.GrantXP(amt)
+
+	if xpScale != 100 {
+		u.SendText(fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi> <ansi fg="yellow">(%d%% scale)</ansi>! <ansi fg="7">(%s)</ansi>`, grantXP, xpScale, source))
+	} else {
+		u.SendText(fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi>! <ansi fg="7">(%s)</ansi>`, grantXP, source))
+	}
+
+}
+
 func (u *UserRecord) Command(inputTxt string, waitTurns ...int) {
 
 	wt := 0

--- a/world.go
+++ b/world.go
@@ -1649,15 +1649,7 @@ func (w *World) TurnTick() {
 			}
 			// Experience reward?
 			if questInfo.Rewards.Experience > 0 {
-
-				grantXP, xpScale := questUser.Character.GrantXP(questInfo.Rewards.Experience)
-
-				xpMsgExtra := ``
-				if xpScale != 100 {
-					xpMsgExtra = fmt.Sprintf(` <ansi fg="yellow">(%d%% scale)</ansi>`, xpScale)
-				}
-
-				questUser.SendText(fmt.Sprintf(`You receive <ansi fg="experience">%d experience points</ansi>%s!`, grantXP, xpMsgExtra))
+				questUser.GrantXP(questInfo.Rewards.Experience, `quest progress`)
 			}
 			// Skill reward?
 			if questInfo.Rewards.SkillInfo != `` {


### PR DESCRIPTION
# Changes

* Experience granting done through user.GrantXP() will now use a centralized message and include the reason for the xp (combat, trash cleanup, etc)
* Added a script command to grantXP to actors
* Added an admin command to `grant <username> <amount> experience`