### PR TITLE
Adding ephemeral `history` for users

### DIFF
--- a/_datafiles/keywords.yaml
+++ b/_datafiles/keywords.yaml
@@ -68,6 +68,7 @@ help:
       - who
       - time
       - leaderboard
+      - history
     items:
       - drop
       - drink
@@ -123,13 +124,14 @@ help:
   admin:
     all:
       - badcommands
-      - build
       - buff
+      - build
       - command
       - deafen
+      - grant
       - locate
-      - mudmail
       - modify
+      - mudmail
       - mute
       - prepare
       - questtoken
@@ -137,7 +139,6 @@ help:
       - reload
       - rename
       - room
-      - questtoken
       - server
       - skillset
       - spawn
@@ -175,6 +176,8 @@ help-aliases:
   pets:             [pet]
   macros:           [macro]
   leaderboard:      [leaderboards, highscore, topscore]
+  history:          ['log']
+  time:             ['date']
 # Default aliases for commands
 # For example: inv -> inventory
 # They can be command + argument aliases
@@ -211,6 +214,8 @@ command-aliases:
   buy:              ['hire']
   trash:            ['junk']
   put:              ['place']
+  leaderboard:      ['leaderboards', 'highscore', 'topscore']
+  history:          ['log']
   'party chat':     ['pchat', 'psay']
   'bank deposit':   ['deposit']
   'bank withdraw':  ['withdraw']
@@ -219,7 +224,6 @@ command-aliases:
   'rank back':      ['backrank']
   'rank front':     ['frontrank']
   'auction bid':    ['bid']
-  'leaderboard':    ['leaderboards', 'highscore', 'topscore']
   
   # Direction aliases
 direction-aliases:

--- a/_datafiles/templates/help/history.template
+++ b/_datafiles/templates/help/history.template
@@ -1,0 +1,12 @@
+<ansi fg="black-bold">.:</ansi> <ansi fg="magenta">Help for </ansi><ansi fg="command">history</ansi>
+
+The <ansi fg="command">history</ansi> shows a list of logged events for your character.
+
+<ansi fg="yellow">Usage: </ansi>
+
+  <ansi fg="command">history</ansi>
+  Show all history for all categories.
+
+  <ansi fg="command">history [category name]</ansi>
+  Show all history for the category name supplied, such as "experience".
+

--- a/internal/inputhandlers/systemcommands.go
+++ b/internal/inputhandlers/systemcommands.go
@@ -110,6 +110,7 @@ func trySystemCommand(cmd string, connectionId connections.ConnectionId) bool {
 	//fmt.Printf("cmd:[%s] arg:[%s]\n", cmd, arg)
 
 	if cmd == "quit" {
+
 		// Not building complex output, so just preparse the ansi in the template and cache that
 		tplTxt, _ := templates.Process("goodbye", nil, templates.AnsiTagsPreParse)
 

--- a/internal/usercommands/character.go
+++ b/internal/usercommands/character.go
@@ -187,6 +187,8 @@ func Character(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 			}
 			characters.SaveAlts(user.Username, newAlts)
 
+			user.EventLog.Add(`character`, `You deleted your alt character, <ansi fg="username">`+match+`</ansi>`)
+
 			user.SendText(`<ansi fg="username">` + match + `</ansi> <ansi fg="red">is deleted.</ansi>`)
 			user.ClearPrompt()
 			return true, nil
@@ -260,6 +262,8 @@ func Character(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 			user.Character.RoomId = room.RoomId
 
 			users.SaveUser(*user)
+
+			user.EventLog.Add(`character`, `You dematerialize as <ansi fg="username">`+oldName+`</ansi>. and rematerialize as <ansi fg="username">`+char.Name+`</ansi>`)
 
 			user.SendText(term.CRLFStr + `You dematerialize as <ansi fg="username">` + oldName + `</ansi>. and rematerialize as <ansi fg="username">` + char.Name + `</ansi>!` + term.CRLFStr)
 			room.SendText(`<ansi fg="username">`+oldName+`</ansi> vanishes, and <ansi fg="username">`+char.Name+`</ansi> appears in a shower of sparks!`, user.UserId)
@@ -417,6 +421,8 @@ func Character(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 
 			m.Character.Charm(user.UserId, -1, `suicide vanish`)
 			user.Character.TrackCharmed(m.InstanceId, true)
+
+			user.EventLog.Add(`character`, `You hired your alt character <ansi fg="username">`+m.Character.Name+`</ansi> to help you out`)
 
 			user.SendText(`<ansi fg="username">` + m.Character.Name + `</ansi> appears to help you out!`)
 			room.SendText(`<ansi fg="username">`+m.Character.Name+`</ansi> appears to help <ansi fg="username">`+user.Character.Name+`</ansi>!`, user.UserId)

--- a/internal/usercommands/history.go
+++ b/internal/usercommands/history.go
@@ -1,0 +1,45 @@
+package usercommands
+
+import (
+	"github.com/volte6/gomud/internal/configs"
+	"github.com/volte6/gomud/internal/rooms"
+	"github.com/volte6/gomud/internal/templates"
+	"github.com/volte6/gomud/internal/users"
+)
+
+func History(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+
+	headers := []string{`Category` /*`Round`,*/, `Time`, `Log`}
+
+	rows := [][]string{}
+
+	formatting := []string{
+		`<ansi fg="red">%s</ansi>`,
+		//`<ansi fg="red">%s</ansi>`,
+		`<ansi fg="magenta">%s</ansi>`,
+		`<ansi fg="white-bold">%s</ansi>`,
+	}
+
+	tFormat := string(configs.GetConfig().TimeFormat)
+
+	for _, itm := range user.EventLog {
+
+		if rest != `` && rest != itm.Category {
+			continue
+		}
+
+		rows = append(rows, []string{
+			itm.Category,
+			//fmt.Sprintf(`%d`, itm.WhenRound),
+			itm.WhenTime.Format(tFormat),
+			itm.What,
+		})
+
+	}
+
+	searchResultsTable := templates.GetTable(`History`, headers, rows, formatting)
+	tplTxt, _ := templates.Process("tables/generic", searchResultsTable)
+	user.SendText(tplTxt)
+
+	return true, nil
+}

--- a/internal/usercommands/start.go
+++ b/internal/usercommands/start.go
@@ -126,6 +126,8 @@ func Start(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 		user.SendText(fmt.Sprintf(`You will be known as <ansi fg="yellow-bold">%s</ansi>!%s`, user.Character.Name, term.CRLFStr))
 	}
 
+	user.EventLog.Add(`character`, fmt.Sprintf(`You created a new character (<ansi fg="username">%s</ansi>)`, user.Character.Name))
+
 	user.SendText(fmt.Sprintf(`<ansi fg="magenta">Suddenly, a vortex appears before you, drawing you in before you have any chance to react!</ansi>%s`, term.CRLFStr))
 
 	for _, ridStr := range configs.GetConfig().TutorialStartRooms {

--- a/internal/usercommands/suicide.go
+++ b/internal/usercommands/suicide.go
@@ -50,7 +50,7 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 
 		} else {
 
-			user.EventLog.Add(`death`, fmt.Sprintf(`You (<ansi fg="username">%s</ansi>) have <ansi fg="red-bold">PERMA-DIED</ansi>`, user.Character.Name))
+			user.EventLog.Add(`death`, fmt.Sprintf(`You (<ansi fg="username">%s</ansi>) has <ansi fg="red-bold">PERMA-DIED</ansi>`, user.Character.Name))
 
 			// Perma-died!!!
 			textOut, _ := templates.Process("character/permadeath", nil)
@@ -72,7 +72,7 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 
 	}
 
-	user.EventLog.Add(`death`, fmt.Sprintf(`You (<ansi fg="username">%s</ansi>) have <ansi fg="red-bold">DIED</ansi>`, user.Character.Name))
+	user.EventLog.Add(`death`, fmt.Sprintf(`You (<ansi fg="username">%s</ansi>) has <ansi fg="red-bold">DIED</ansi>`, user.Character.Name))
 
 	if config.OnDeathEquipmentDropChance >= 0 {
 		chanceInt := int(config.OnDeathEquipmentDropChance * 100)

--- a/internal/usercommands/suicide.go
+++ b/internal/usercommands/suicide.go
@@ -50,6 +50,8 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 
 		} else {
 
+			user.EventLog.Add(`death`, fmt.Sprintf(`You (<ansi fg="username">%s</ansi>) have <ansi fg="red-bold">PERMA-DIED</ansi>`, user.Character.Name))
+
 			// Perma-died!!!
 			textOut, _ := templates.Process("character/permadeath", nil)
 			user.SendText(colorpatterns.ApplyColorPattern(textOut, `red`))
@@ -70,6 +72,8 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 
 	}
 
+	user.EventLog.Add(`death`, fmt.Sprintf(`You (<ansi fg="username">%s</ansi>) have <ansi fg="red-bold">DIED</ansi>`, user.Character.Name))
+
 	if config.OnDeathEquipmentDropChance >= 0 {
 		chanceInt := int(config.OnDeathEquipmentDropChance * 100)
 		for _, itm := range user.Character.GetAllWornItems() {
@@ -84,16 +88,21 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 	}
 
 	if user.Character.Gold > 0 {
+		user.EventLog.Add(`death`, fmt.Sprintf(`You dropped <ansi fg="gold">%d gold</ansi> on death`, user.Character.Gold))
 		Drop(fmt.Sprintf(`%d gold`, user.Character.Gold), user, room)
 	}
 
 	if config.OnDeathAlwaysDropBackpack {
 		Drop("all", user, room)
+
+		user.EventLog.Add(`death`, `You dropped <ansi fg="alert-3">everthing in your backpack</ansi> on death`)
+
 	} else if config.OnDeathEquipmentDropChance >= 0 {
 		chanceInt := int(config.OnDeathEquipmentDropChance * 100)
 		for _, itm := range user.Character.GetAllBackpackItems() {
 			if util.Rand(100) < chanceInt {
 				Drop(itm.Name(), user, room)
+				user.EventLog.Add(`death`, fmt.Sprintf(`You dropped your <ansi fg="itemname">%s</ansi> on death`, itm.Name()))
 			}
 		}
 	}
@@ -110,12 +119,17 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 				user.Character.Level++
 
 				user.SendText(fmt.Sprintf(`You lost <ansi fg="yellow">%d experience points</ansi>.`, oldExperience-user.Character.Experience))
+
+				user.EventLog.Add(`death`, fmt.Sprintf(`You lost <ansi fg="yellow">%d experience points</ansi>. on death`, oldExperience-user.Character.Experience))
+
 			} else if lossPct > 0 { // Are they losing a set %?
 
 				loss := int(math.Floor(float64(user.Character.Experience) * lossPct))
 				user.Character.Experience -= loss
 
 				user.SendText(fmt.Sprintf(`You lost <ansi fg="yellow">%d experience points</ansi>.`, loss))
+
+				user.EventLog.Add(`death`, fmt.Sprintf(`You lost <ansi fg="yellow">%d experience points</ansi>. on death`, loss))
 			}
 		}
 

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -73,6 +73,7 @@ var (
 		`help`:        {Help, true, false},
 		`keyring`:     {KeyRing, true, false},
 		`killstats`:   {Killstats, true, false},
+		`history`:     {History, true, false},
 		`inbox`:       {Inbox, true, false},
 		`inspect`:     {Inspect, false, false},
 		`inventory`:   {Inventory, true, false},

--- a/internal/users/userlog.go
+++ b/internal/users/userlog.go
@@ -1,0 +1,64 @@
+package users
+
+import (
+	"time"
+
+	"github.com/volte6/gomud/internal/util"
+)
+
+const (
+	LogMinAllocation = 50
+	LogMaxAllocation = 1000
+)
+
+type UserLogEntry struct {
+	Category  string    // optional category such as "combat" "communication" etc
+	WhenRound uint64    // Game round it occured
+	WhenTime  time.Time // Actual time it occured
+	What      string    // String describing occurance
+}
+
+type UserLog []UserLogEntry
+
+func (ul *UserLog) Add(cat string, message string) {
+
+	if LogMinAllocation < 1 { // disables log if <1
+		return
+	}
+
+	if len(*ul) == cap(*ul) {
+
+		if cap(*ul) < LogMaxAllocation {
+
+			newUL := make(UserLog, len(*ul), cap(*ul)+LogMinAllocation)
+			copy(newUL, *ul)
+			*ul = newUL
+
+		} else {
+
+			newUL := make(UserLog, len(*ul)-1, LogMaxAllocation)
+			copy(newUL, (*ul)[1:])
+			*ul = newUL
+
+		}
+
+	}
+
+	newEntry := UserLogEntry{
+		Category:  cat,
+		WhenTime:  time.Now(),
+		WhenRound: util.GetRoundCount(),
+		What:      message,
+	}
+
+	*ul = append(*ul, newEntry)
+
+}
+
+func (ul *UserLog) Items(yield func(UserLogEntry) bool) {
+	for _, v := range *ul {
+		if !yield(v) {
+			return
+		}
+	}
+}

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -48,6 +48,7 @@ type UserRecord struct {
 	Inbox          Inbox                 `yaml:"inbox,omitempty"`
 	Muted          bool                  `yaml:"muted,omitempty"`    // Cannot SEND custom communications to anyone but admin/mods
 	Deafened       bool                  `yaml:"deafened,omitempty"` // Cannot HEAR custom communications from anyone but admin/mods
+	EventLog       UserLog               `yaml:"-"`                  // Do not retain in user file (for now)
 	connectionId   uint64
 	unsentText     string
 	suggestText    string
@@ -74,6 +75,7 @@ func NewUserRecord(userId int, connectionId uint64) *UserRecord {
 		Joined:         time.Now(),
 		connectionTime: time.Now(),
 		tempDataStore:  make(map[string]any),
+		EventLog:       UserLog{},
 	}
 
 	if c.PermaDeath {
@@ -129,9 +131,16 @@ func (u *UserRecord) GrantXP(amt int, source string) {
 	grantXP, xpScale := u.Character.GrantXP(amt)
 
 	if xpScale != 100 {
-		u.SendText(fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi> <ansi fg="yellow">(%d%% scale)</ansi>! <ansi fg="7">(%s)</ansi>`, grantXP, xpScale, source))
+		msg := fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi> <ansi fg="yellow">(%d%% scale)</ansi>! <ansi fg="7">(%s)</ansi>`, grantXP, xpScale, source)
+		u.SendText(msg)
+
+		u.EventLog.Add(`experience`, msg)
+
 	} else {
-		u.SendText(fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi>! <ansi fg="7">(%s)</ansi>`, grantXP, source))
+		msg := fmt.Sprintf(`You gained <ansi fg="yellow-bold">%d experience points</ansi>! <ansi fg="7">(%s)</ansi>`, grantXP, source)
+		u.SendText(msg)
+
+		u.EventLog.Add(`experience`, msg)
 	}
 
 }

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -211,6 +211,8 @@ func LoginUser(u *UserRecord, connectionId connections.ConnectionId) (*UserRecor
 				// Set their input round to current to track idle time fresh
 				u.SetLastInputRound(util.GetRoundCount())
 
+				u.EventLog.Add(`connection`, `Reconnected`)
+
 				return u, "Reconnecting...", nil
 			}
 
@@ -236,6 +238,9 @@ func LoginUser(u *UserRecord, connectionId connections.ConnectionId) (*UserRecor
 	userManager.UserConnections[u.UserId] = u.connectionId
 
 	slog.Info("LOGIN", "userId", u.UserId)
+
+	u.EventLog.Add(`connection`, `Connected`)
+
 	for _, mobInstId := range u.Character.GetCharmIds() {
 		if !mobs.MobInstanceExists(mobInstId) {
 			u.Character.TrackCharmed(mobInstId, false)

--- a/main.go
+++ b/main.go
@@ -350,6 +350,8 @@ func handleTelnetConnection(connDetails *connections.ConnectionDetails, wg *sync
 			// If failed to read from the connection, switch to zombie state
 			if userObject != nil {
 
+				userObject.EventLog.Add(`connection`, `Disconnected`)
+
 				if c.ZombieSeconds > 0 {
 
 					connDetails.SetState(connections.Zombie)

--- a/world.go
+++ b/world.go
@@ -111,6 +111,8 @@ func (w *World) enterWorld(userId int, roomId int) {
 		return
 	}
 
+	user.EventLog.Add(`connection`, `Entered world`)
+
 	users.RemoveZombieUser(userId)
 
 	room := rooms.LoadRoom(user.Character.RoomId)
@@ -1751,5 +1753,8 @@ func (w *World) Kick(userId int) {
 		return
 	}
 	users.SetZombieUser(userId)
+
+	user.EventLog.Add(`connection`, `Kicked`)
+
 	connections.Kick(user.ConnectionId())
 }


### PR DESCRIPTION
# Changes
* Users can now view a log of recent activity through the `history` (alias: `log`) command.
* Can narrow down logs by category such as `history experience`

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/859a5d14-f3e8-4bd3-9234-ea98fb5c9baa">

