### PR TITLE
Magic fixes, admin commands, self keywords

### DIFF
--- a/_datafiles/ansi-aliases.yaml
+++ b/_datafiles/ansi-aliases.yaml
@@ -149,6 +149,7 @@ color8:
   mutator: 10
   buff: 4
   buff-text: 14
+  script-text: 10
 color256:
   table-title: 2
   userid: black
@@ -292,3 +293,4 @@ color256:
   mutator: 49
   buff: 147
   buff-text: 14
+  script-text: 155

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -336,6 +336,8 @@ BannedNames:
 - "player*"
 - "user*"
 - "me"
+- "myself"
+- "self"
 - "us"
 - "you"
 - "them"

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -159,9 +159,9 @@ StartRoom: 1
 TutorialStartRooms: [900, 990]
 # - PermaDeath - 
 #   If true, players lose their character if they die with zero lives left.
-PermaDeath: true
+PermaDeath: false
 # - LivesStart - 
-#   (Req: PermaDeath) Hhow many lives players start with before being reset.
+#   (Req: PermaDeath) How many lives players start with before being reset.
 LivesStart: 3
 # - LivesMax - 
 #   (Req: PermaDeath) The maximum lives a player can have.

--- a/_datafiles/keywords.yaml
+++ b/_datafiles/keywords.yaml
@@ -144,6 +144,7 @@ help:
       - modify
       - mudmail
       - mute
+      - paz
       - prepare
       - questtoken
       - redescribe

--- a/_datafiles/mutators/pushed_boulder.yaml
+++ b/_datafiles/mutators/pushed_boulder.yaml
@@ -1,0 +1,8 @@
+# This mutator is used when players push a boulder in room 593
+mutatorid: pushed-boulder 
+alertmodifier: 
+  text: The boulder has been pushed aside to reveal a pathway!
+decayrate: 1 hour
+exits:
+  pathway:
+    roomid: 1001

--- a/_datafiles/rooms/stormshards/1001.yaml
+++ b/_datafiles/rooms/stormshards/1001.yaml
@@ -1,0 +1,10 @@
+roomid: 1001
+zone: Stormshards
+title: Hidden Path
+description: Just behind a boulder is this hidden path. The plants and overgrowth
+  make it hard to see, but you can make a way to continue along the path, or you can
+  return to the main raod.
+biome: mountains
+exits:
+  road:
+    roomid: 593

--- a/_datafiles/rooms/stormshards/593.js
+++ b/_datafiles/rooms/stormshards/593.js
@@ -1,0 +1,28 @@
+
+const verbs = ["roll", "push"];
+const nouns = ["boulder", "rock"];
+
+// Generic Command Handler
+function onCommand(cmd, rest, user, room) {
+
+    if ( !verbs.includes(cmd) ) {
+        return false;
+    }
+    
+    matches = UtilFindMatchIn(rest, nouns);
+    if ( !matches.found ) {
+        return false;
+    }
+
+    if ( room.HasMutator('pushed-boulder') ) {
+        SendUserMessage(user.UserId(), "The boulder is already pushed aside.");
+        return true;
+    }
+
+    SendUserMessage(user.UserId(), "You roll the boulder to the side, revealing a pathway!");
+
+    room.AddMutator('pushed-boulder');
+        
+    return true;
+}
+

--- a/_datafiles/rooms/stormshards/593.yaml
+++ b/_datafiles/rooms/stormshards/593.yaml
@@ -1,13 +1,16 @@
 roomid: 593
 zone: Stormshards
 title: Mountain path
-description: As the path ascends, the terrain becomes more rugged; the trees thin
-  out, giving way to rocky outcrops and steep, craggy inclines. The earth underfoot
-  changes to a mix of loose shale and solid stone, and the incline sharpens, challenging
-  even the most seasoned travelers.
+description: As the path winds upward, the surroundings become more barren; dwindling
+  trees give way to craggy rocks and steep slopes. The terrain underfoot shifts to
+  loose shale mingled with solid stone, and a large boulder rests subtly beside the
+  trail, almost blending into the rugged backdrop. The sharp incline pushes even experienced
+  travelers to their limits.
 biome: mountains
 exits:
   northeast:
     roomid: 594
   south:
     roomid: 592
+nouns:
+  boulder: off the path lies a boulder.

--- a/_datafiles/templates/admincommands/help/command.paz.template
+++ b/_datafiles/templates/admincommands/help/command.paz.template
@@ -1,0 +1,4 @@
+The <ansi fg="command">paz</ansi> command can be used in the following ways:
+
+<ansi fg="command">paz</ansi> - Brings yourself to maximum hp/mp.
+<ansi fg="command">pax [target]</ansi> - Brings the target to maximum hp/mp.

--- a/_datafiles/templates/admincommands/help/command.zap.template
+++ b/_datafiles/templates/admincommands/help/command.zap.template
@@ -1,3 +1,4 @@
 The <ansi fg="command">zap</ansi> command can be used in the following ways:
 
-<ansi fg="command">zap</ansi> - Brings your currently aggrod mob to 1hp.
+<ansi fg="command">zap</ansi> - Brings your currently aggrod mob to 1hp/1mp.
+<ansi fg="command">zap [target]</ansi> - Brings the target to 1hp/1mp.

--- a/_datafiles/templates/descriptions/who.template
+++ b/_datafiles/templates/descriptions/who.template
@@ -4,7 +4,7 @@
 <ansi fg="room-description{{ if or .IsNight .IsDark }}-dark{{ end }}">Also here: </ansi>
     {{- range $index, $playerName := .VisiblePlayers -}}
         {{- $displayed = add $displayed 1 -}}
-        <ansi fg="username">{{ $playerName }}</ansi>{{- if ne $displayed $whoCt }}{{- if ne $displayed (sub $whoCt 1) }}, {{ else }} and {{ end }}{{ end -}}
+        {{ $playerName }}{{- if ne $displayed $whoCt }}{{- if ne $displayed (sub $whoCt 1) }}, {{ else }} and {{ end }}{{ end -}}
     {{- end }}
     {{- range $index, $mobName := .VisibleMobs -}}
         {{- $displayed = add $displayed 1 -}}

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -42,49 +42,51 @@ const (
 )
 
 type Character struct {
-	Name            string            // The name of the character
-	Description     string            // A description of the character.
-	Adjectives      []string          `yaml:"adjectives,omitempty"` // Decorative text for the name of the character (e.g. "sleeping", "dead", "wounded")
-	RoomId          int               // The room id the character is in.
-	Zone            string            // The zone the character is in. The folder the room can be located in too.
-	RaceId          int               // Character race
-	Stats           stats.Statistics  // Character stats
-	Level           int               // The level of the character
-	Experience      int               // The experience of the character
-	TrainingPoints  int               // The number of training points the character has
-	StatPoints      int               // The number of skill points the character has
-	Health          int               // The health of the character
-	Mana            int               // The mana of the character
-	ActionPoints    int               // The resevoir of action points the character has to spend on movement etc.
-	Alignment       int8              // The alignment of the character
-	Gold            int               // The gold the character is holding
-	Bank            int               // The gold the character has in the bank
-	Shop            Shop              `yaml:"shop,omitempty"`          // Definition of shop services/items this character stocks (or just has at the moment)
-	SpellBook       map[string]int    `yaml:"spellbook,omitempty"`     // The spells the character has learned
-	Charmed         *CharmInfo        `yaml:"-"`                       // If they are charmed, this is the info
-	CharmedMobs     []int             `yaml:"-"`                       // If they have charmed anyone, this is the list of mob instance ids
-	Items           []items.Item      `yaml:"items,omitempty"`         // The items the character is holding
-	Buffs           buffs.Buffs       `yaml:"buffs,omitempty"`         // The buffs the character has active
-	Equipment       Worn              `yaml:"equipment,omitempty"`     // The equipment the character is wearing
-	TNLScale        float32           `yaml:"-"`                       // The experience scale of the character. Don't write to yaml since is dynamically calculated.
-	HealthMax       stats.StatInfo    `yaml:"-"`                       // The maximum health of the character. Don't write to yaml since is dynamically calculated.
-	ManaMax         stats.StatInfo    `yaml:"-"`                       // The maximum mana of the character. Don't write to yaml since is dynamically calculated.
-	ActionPointsMax stats.StatInfo    `yaml:"-"`                       // The maximum actions of character. Don't write to yaml since is dynamically calculated.
-	Aggro           *Aggro            `yaml:"-"`                       // Dont' store this. If they leave they break their aggro
-	Skills          map[string]int    `yaml:"skills,omitempty"`        // The skills the character has, and what level they are at
-	Cooldowns       Cooldowns         `yaml:"cooldowns,omitempty"`     // How many rounds until it is cooled down
-	Settings        map[string]string `yaml:"settings,omitempty"`      // custom setting tracking, used for anything.
-	QuestProgress   map[int]string    `yaml:"questprogress,omitempty"` // quest progress tracking
-	KeyRing         map[string]string `yaml:"keyring,omitempty"`       // key is the lock id, value is the sequence
-	KD              KDStats           `yaml:"kd,omitempty"`            // Kill/Death stats
-	MiscData        map[string]any    `yaml:"miscdata,omitempty"`      // Any random other data that needs to be stored
-	ExtraLives      int               `yaml:"extralives,omitempty"`    // How many lives remain. If enabled, players can perma-die if they die at zero
-	MobMastery      MobMasteries      `yaml:"mobmastery,omitempty"`    // Tracks particular masteries around a given mob
-	Pet             pets.Pet          `yaml:"pet,omitempty"`           // Do they have a pet?
-	Created         time.Time         `yaml:"created"`                 // When this character was created
-	roomHistory     []int             // A stack FILO of the last X rooms the character has been in
-	followers       []int             // everyone following this user
-	permaBuffIds    []int             // Buff Id's that are always present for this character
+	Name             string            // The name of the character
+	Description      string            // A description of the character.
+	Adjectives       []string          `yaml:"adjectives,omitempty"` // Decorative text for the name of the character (e.g. "sleeping", "dead", "wounded")
+	RoomId           int               // The room id the character is in.
+	Zone             string            // The zone the character is in. The folder the room can be located in too.
+	RaceId           int               // Character race
+	Stats            stats.Statistics  // Character stats
+	Level            int               // The level of the character
+	Experience       int               // The experience of the character
+	TrainingPoints   int               // The number of training points the character has
+	StatPoints       int               // The number of skill points the character has
+	Health           int               // The health of the character
+	Mana             int               // The mana of the character
+	ActionPoints     int               // The resevoir of action points the character has to spend on movement etc.
+	Alignment        int8              // The alignment of the character
+	Gold             int               // The gold the character is holding
+	Bank             int               // The gold the character has in the bank
+	Shop             Shop              `yaml:"shop,omitempty"`          // Definition of shop services/items this character stocks (or just has at the moment)
+	SpellBook        map[string]int    `yaml:"spellbook,omitempty"`     // The spells the character has learned
+	Charmed          *CharmInfo        `yaml:"-"`                       // If they are charmed, this is the info
+	CharmedMobs      []int             `yaml:"-"`                       // If they have charmed anyone, this is the list of mob instance ids
+	Items            []items.Item      `yaml:"items,omitempty"`         // The items the character is holding
+	Buffs            buffs.Buffs       `yaml:"buffs,omitempty"`         // The buffs the character has active
+	Equipment        Worn              `yaml:"equipment,omitempty"`     // The equipment the character is wearing
+	TNLScale         float32           `yaml:"-"`                       // The experience scale of the character. Don't write to yaml since is dynamically calculated.
+	HealthMax        stats.StatInfo    `yaml:"-"`                       // The maximum health of the character. Don't write to yaml since is dynamically calculated.
+	ManaMax          stats.StatInfo    `yaml:"-"`                       // The maximum mana of the character. Don't write to yaml since is dynamically calculated.
+	ActionPointsMax  stats.StatInfo    `yaml:"-"`                       // The maximum actions of character. Don't write to yaml since is dynamically calculated.
+	Aggro            *Aggro            `yaml:"-"`                       // Dont' store this. If they leave they break their aggro
+	Skills           map[string]int    `yaml:"skills,omitempty"`        // The skills the character has, and what level they are at
+	Cooldowns        Cooldowns         `yaml:"cooldowns,omitempty"`     // How many rounds until it is cooled down
+	Settings         map[string]string `yaml:"settings,omitempty"`      // custom setting tracking, used for anything.
+	QuestProgress    map[int]string    `yaml:"questprogress,omitempty"` // quest progress tracking
+	KeyRing          map[string]string `yaml:"keyring,omitempty"`       // key is the lock id, value is the sequence
+	KD               KDStats           `yaml:"kd,omitempty"`            // Kill/Death stats
+	MiscData         map[string]any    `yaml:"miscdata,omitempty"`      // Any random other data that needs to be stored
+	ExtraLives       int               `yaml:"extralives,omitempty"`    // How many lives remain. If enabled, players can perma-die if they die at zero
+	MobMastery       MobMasteries      `yaml:"mobmastery,omitempty"`    // Tracks particular masteries around a given mob
+	Pet              pets.Pet          `yaml:"pet,omitempty"`           // Do they have a pet?
+	Created          time.Time         `yaml:"created"`                 // When this character was created
+	roomHistory      []int             // A stack FILO of the last X rooms the character has been in
+	PlayerDamage     map[int]int       `yaml:"-"` // key = who, value = how much
+	LastPlayerDamage uint64            `yaml:"-"` // last round a player damaged this character
+	followers        []int             // everyone following this user
+	permaBuffIds     []int             // Buff Id's that are always present for this character
 }
 
 func New() *Character {
@@ -123,6 +125,7 @@ func New() *Character {
 		roomHistory:    make([]int, 0, 10),
 		KeyRing:        make(map[string]string),
 		Created:        time.Now(),
+		PlayerDamage:   map[int]int{},
 	}
 }
 
@@ -135,6 +138,24 @@ func (c *Character) GetDescription() string {
 	}
 	hash := strings.TrimPrefix(c.Description, `h:`)
 	return descriptionCache[hash]
+}
+
+// returns description unless description is a hash
+// which points to another description location.
+func (c *Character) TrackPlayerDamage(userId int, damageAmt int) {
+
+	roundNow := util.GetRoundCount()
+	if len(c.PlayerDamage) == 0 {
+		c.PlayerDamage = map[int]int{}
+	} else {
+		if roundNow-c.LastPlayerDamage > 30 {
+			clear(c.PlayerDamage)
+		}
+	}
+
+	c.PlayerDamage[userId] = c.PlayerDamage[userId] + damageAmt
+	c.LastPlayerDamage = roundNow
+
 }
 
 /*

--- a/internal/characters/kdstats.go
+++ b/internal/characters/kdstats.go
@@ -1,16 +1,30 @@
 package characters
 
+import "fmt"
+
 type KDStats struct {
 	TotalKills  int         `json:"totalkills"`  // Quick tally of kills
 	Kills       map[int]int `json:"kills"`       // map of MobId to count
 	TotalDeaths int         `json:"totaldeaths"` // Quick tally of deaths
+
+	TotalPvpKills  int            `json:"totalpvpkills"`  // Quick tally of pvp kills
+	PlayerKills    map[string]int `json:"playerkills"`    // map of userid:username to count
+	PlayerDeaths   map[string]int `json:"playerdeaths"`   // map of userid:username to count
+	TotalPvpDeaths int            `json:"totalpvpdeaths"` // Quick tally of pvp deaths
 }
 
-func (kd *KDStats) GetKDRatio() float64 {
+func (kd *KDStats) GetMobKDRatio() float64 {
 	if kd.TotalDeaths == 0 {
 		return float64(kd.TotalKills)
 	}
 	return float64(kd.TotalKills) / float64(kd.TotalDeaths)
+}
+
+func (kd *KDStats) GetPvpKDRatio() float64 {
+	if kd.TotalPvpDeaths == 0 {
+		return float64(kd.TotalPvpKills)
+	}
+	return float64(kd.TotalPvpKills) / float64(kd.TotalPvpDeaths)
 }
 
 func (kd *KDStats) GetMobKills(mobId ...int) int {
@@ -29,6 +43,26 @@ func (kd *KDStats) GetMobKills(mobId ...int) int {
 	return total
 }
 
+func (kd *KDStats) AddPlayerKill(killedUserId int, killedCharName string) {
+	if kd.PlayerKills == nil {
+		kd.PlayerKills = make(map[string]int)
+	}
+
+	keyName := fmt.Sprintf(`%d:%s`, killedUserId, killedCharName)
+
+	kd.TotalPvpKills++
+	kd.PlayerKills[keyName] = kd.PlayerKills[keyName] + 1
+}
+
+func (kd *KDStats) AddPlayerDeath(killedByUserId int, killedByCharName string) {
+	if kd.PlayerDeaths == nil {
+		kd.PlayerDeaths = make(map[string]int)
+	}
+
+	keyName := fmt.Sprintf(`%d:%s`, killedByUserId, killedByCharName)
+	kd.PlayerDeaths[keyName] = kd.PlayerDeaths[keyName] + 1
+}
+
 func (kd *KDStats) AddMobKill(mobId int) {
 	if kd.Kills == nil {
 		kd.Kills = make(map[int]int)
@@ -37,10 +71,18 @@ func (kd *KDStats) AddMobKill(mobId int) {
 	kd.Kills[mobId] = kd.Kills[mobId] + 1
 }
 
-func (kd *KDStats) GetDeaths() int {
+func (kd *KDStats) GetMobDeaths() int {
 	return kd.TotalDeaths
 }
 
-func (kd *KDStats) AddDeath() {
+func (kd *KDStats) GetPvpDeaths() int {
+	return kd.TotalPvpDeaths
+}
+
+func (kd *KDStats) AddMobDeath() {
 	kd.TotalDeaths++
+}
+
+func (kd *KDStats) AddPvpDeath() {
+	kd.TotalPvpDeaths++
 }

--- a/internal/combat/combat.go
+++ b/internal/combat/combat.go
@@ -36,10 +36,7 @@ func AttackPlayerVsMob(user *users.UserRecord, mob *mobs.Mob) AttackResult {
 	mob.Character.ApplyHealthChange(attackResult.DamageToTarget * -1)
 
 	// Remember who has hit him
-	if _, ok := mob.DamageTaken[user.UserId]; !ok {
-		mob.DamageTaken[user.UserId] = 0
-	}
-	mob.DamageTaken[user.UserId] += attackResult.DamageToTarget
+	mob.Character.TrackPlayerDamage(user.UserId, attackResult.DamageToTarget)
 
 	return attackResult
 }
@@ -77,10 +74,7 @@ func AttackMobVsMob(mobAtk *mobs.Mob, mobDef *mobs.Mob) AttackResult {
 	// If attacking mob was player charmed, attribute damage done to that player
 	if charmedUserId := mobAtk.Character.GetCharmedUserId(); charmedUserId > 0 {
 		// Remember who has hit him
-		if _, ok := mobDef.DamageTaken[charmedUserId]; !ok {
-			mobDef.DamageTaken[charmedUserId] = 0
-		}
-		mobDef.DamageTaken[charmedUserId] += attackResult.DamageToTarget
+		mobDef.Character.TrackPlayerDamage(charmedUserId, attackResult.DamageToTarget)
 	}
 
 	return attackResult

--- a/internal/mobcommands/suicide.go
+++ b/internal/mobcommands/suicide.go
@@ -81,21 +81,21 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 
 	partyTracker := map[int]int{} // key is party leader ID, value is how much will be shared.
 
-	if len(mob.DamageTaken) > 0 {
+	if len(mob.Character.PlayerDamage) > 0 {
 
-		xpVal = xpVal / len(mob.DamageTaken)        // Div by number of players that beat him up
-		xpVal += ((util.Rand(3) - 1) * xpVariation) // a little bit of variation
+		xpVal = xpVal / len(mob.Character.PlayerDamage) // Div by number of players that beat him up
+		xpVal += ((util.Rand(3) - 1) * xpVariation)     // a little bit of variation
 
 		totalPlayerLevels := 0
-		for uId, _ := range mob.DamageTaken {
+		for uId, _ := range mob.Character.PlayerDamage {
 			if user := users.GetByUserId(uId); user != nil {
 				totalPlayerLevels += user.Character.Level
 			}
 		}
 
-		attackerCt := len(mob.DamageTaken)
+		attackerCt := len(mob.Character.PlayerDamage)
 
-		for uId, _ := range mob.DamageTaken {
+		for uId, _ := range mob.Character.PlayerDamage {
 			if user := users.GetByUserId(uId); user != nil {
 
 				scripting.TryMobScriptEvent(`onDie`, mob.InstanceId, uId, `user`, map[string]any{`attackerCount`: attackerCt})

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -55,20 +55,19 @@ type MobId int // Creating a custom type to help prevent confusion over MobId an
 
 type Mob struct {
 	MobId           MobId
-	Zone            string      `yaml:"zone,omitempty"`
-	ItemDropChance  int         // chance in 100
-	ActivityLevel   int         `yaml:"activitylevel,omitempty"` // 1 - 10%, 10 = 100%
-	InstanceId      int         `yaml:"-"`
-	HomeRoomId      int         `yaml:"-"`
-	Hostile         bool        // whether they attack on sight
-	LastIdleCommand uint8       `yaml:"-"` // Track what hte last used idlecommand was
-	BoredomCounter  uint8       `yaml:"-"` // how many rounds have passed since this mob has seen a player
-	Groups          []string    // What group do they identify with? Helps with teamwork
-	Hates           []string    `yaml:"hates,omitempty"`        // What NPC groups or races do they hate and probably fight if encountered?
-	IdleCommands    []string    `yaml:"idlecommands,omitempty"` // Commands they may do while idle (not in combat)
-	AngryCommands   []string    // randomly chosen to queue when they are angry/entering combat.
-	CombatCommands  []string    `yaml:"combatcommands,omitempty"` // Commands they may do while in combat
-	DamageTaken     map[int]int `yaml:"-"`                        // key = who, value = how much
+	Zone            string   `yaml:"zone,omitempty"`
+	ItemDropChance  int      // chance in 100
+	ActivityLevel   int      `yaml:"activitylevel,omitempty"` // 1 - 10%, 10 = 100%
+	InstanceId      int      `yaml:"-"`
+	HomeRoomId      int      `yaml:"-"`
+	Hostile         bool     // whether they attack on sight
+	LastIdleCommand uint8    `yaml:"-"` // Track what hte last used idlecommand was
+	BoredomCounter  uint8    `yaml:"-"` // how many rounds have passed since this mob has seen a player
+	Groups          []string // What group do they identify with? Helps with teamwork
+	Hates           []string `yaml:"hates,omitempty"`        // What NPC groups or races do they hate and probably fight if encountered?
+	IdleCommands    []string `yaml:"idlecommands,omitempty"` // Commands they may do while idle (not in combat)
+	AngryCommands   []string // randomly chosen to queue when they are angry/entering combat.
+	CombatCommands  []string `yaml:"combatcommands,omitempty"` // Commands they may do while in combat
 	Character       characters.Character
 	MaxWander       int      `yaml:"maxwander,omitempty"`       // Max rooms to wander from home
 	GoingHome       bool     `yaml:"-"`                         // WHether they are trying to get home
@@ -141,7 +140,7 @@ func NewMobById(mobId MobId, homeRoomId int, forceLevel ...int) *Mob {
 		mob.HomeRoomId = homeRoomId
 		mob.Character.RoomId = homeRoomId
 		mob.InstanceId = instanceCounter
-		mob.DamageTaken = make(map[int]int)
+		mob.Character.PlayerDamage = make(map[int]int)
 
 		// Level related stuff
 		if len(forceLevel) > 0 && forceLevel[0] > 0 {

--- a/internal/moons/moons.go
+++ b/internal/moons/moons.go
@@ -1,5 +1,0 @@
-package moons
-
-const (
-	MoonTemplatePath = "_datafiles/templates/moons"
-)

--- a/internal/mutators/mutators.go
+++ b/internal/mutators/mutators.go
@@ -92,6 +92,19 @@ func IsMutator(mutName string) bool {
 	return ok
 }
 
+func (ml *MutatorList) Has(mutName string) bool {
+	if _, ok := allMutators[mutName]; !ok {
+		return false
+	}
+
+	for _, mut := range *ml {
+		if mut.MutatorId == mutName {
+			return true
+		}
+	}
+	return false
+}
+
 func (ml *MutatorList) Add(mutName string) bool {
 
 	if _, ok := allMutators[mutName]; !ok {

--- a/internal/scripting/docs/FUNCTIONS_ROOMS.md
+++ b/internal/scripting/docs/FUNCTIONS_ROOMS.md
@@ -21,8 +21,9 @@
   - [RoomObject.SpawnMob(mobId int) Actor](#roomobjectspawnmobmobid-int-actor)
   - [RoomObject.AddTemporaryExit(exitNameSimple string, exitNameFancy string, exitRoomId int, expiresTimeString string](#roomobjectaddtemporaryexitexitnamesimple-string-exitnamefancy-string-exitroomid-int-expirestimestring-string)
   - [RoomObject.RemoveTemporaryExit(exitNameSimple string, exitNameFancy string, exitRoomId int](#roomobjectremovetemporaryexitexitnamesimple-string-exitnamefancy-string-exitroomid-int)
-  - [RoomObject.AddMutator(mutName string](#roomobjectaddmutatormutname-string)
-  - [RoomObject.RemoveMutator(mutName string](#roomobjectremovemutatormutname-string)
+  - [RoomObject.HasMutator(mutName string) bool](#roomobjecthasmutatormutname-string-bool)
+  - [RoomObject.AddMutator(mutName string)](#roomobjectaddmutatormutname-string)
+  - [RoomObject.RemoveMutator(mutName string)](#roomobjectremovemutatormutname-string)
   - [RoomObject.RepeatSpawnItem(itemId int, roundInterval int \[, containerName\]](#roomobjectrepeatspawnitemitemid-int-roundinterval-int--containername)
   - [RoomObject.SetLocked(exitName string, lockIt bool)](#roomobjectsetlockedexitname-string-lockit-bool)
 
@@ -182,7 +183,15 @@ _Note: all 3 parameters much match an existing temporary exit for it to be remov
 | exitNameFancy | Should be the simple name, but can have color tags. |
 | exitRoomId | The roomId the exit should lead to. |
 
-## [RoomObject.AddMutator(mutName string](/internal/scripting/room_func.go)
+
+## [RoomObject.HasMutator(mutName string) bool](/internal/scripting/room_func.go)
+Returns true if the room has the specified mutator
+
+|  Argument | Explanation |
+| --- | --- |
+| mutName | the MutatorId of the mutator. |
+
+## [RoomObject.AddMutator(mutName string)](/internal/scripting/room_func.go)
 Adds a new mutator to a room.
 
 _Note: If the mutator already exists this is ignored._
@@ -191,7 +200,7 @@ _Note: If the mutator already exists this is ignored._
 | --- | --- |
 | mutName | the MutatorId of the mutator. |
 
-## [RoomObject.RemoveMutator(mutName string](/internal/scripting/room_func.go)
+## [RoomObject.RemoveMutator(mutName string)](/internal/scripting/room_func.go)
 Removes a mutator from a room.
 
 _Note: This only expires it. It may be a mutator that respawns, in which case this doens't really completely remove it._

--- a/internal/scripting/room.go
+++ b/internal/scripting/room.go
@@ -45,6 +45,10 @@ func TryRoomScriptEvent(eventName string, userId int, roomId int) (bool, error) 
 
 	if onCommandFunc, ok := vmw.GetFunction(eventName); ok {
 
+		// Set forced ansi tag wrappers
+		userTextWrap.Set(`script-text`, ``, ``)
+		roomTextWrap.Set(`script-text`, ``, ``)
+
 		sUser := GetActor(userId, 0)
 		sRoom := GetRoom(roomId)
 
@@ -59,6 +63,9 @@ func TryRoomScriptEvent(eventName string, userId int, roomId int) (bool, error) 
 
 		vmw.VM.ClearInterrupt()
 		tmr.Stop()
+
+		userTextWrap.Reset()
+		roomTextWrap.Reset()
 
 		if err != nil {
 
@@ -99,6 +106,10 @@ func TryRoomIdleEvent(roomId int) (bool, error) {
 
 	if onCommandFunc, ok := vmw.GetFunction(`onIdle`); ok {
 
+		// Set forced ansi tag wrappers
+		userTextWrap.Set(`script-text`, ``, ``)
+		roomTextWrap.Set(`script-text`, ``, ``)
+
 		sRoom := GetRoom(roomId)
 
 		tmr := time.AfterFunc(scriptRoomTimeout, func() {
@@ -111,6 +122,9 @@ func TryRoomIdleEvent(roomId int) (bool, error) {
 
 		vmw.VM.ClearInterrupt()
 		tmr.Stop()
+
+		userTextWrap.Reset()
+		roomTextWrap.Reset()
 
 		if err != nil {
 
@@ -177,6 +191,10 @@ func TryRoomCommand(cmd string, rest string, userId int) (bool, error) {
 
 	if cmdFound {
 
+		// Set forced ansi tag wrappers
+		userTextWrap.Set(`script-text`, ``, ``)
+		roomTextWrap.Set(`script-text`, ``, ``)
+
 		sUser := GetUser(userId)
 		sRoom := GetRoom(user.Character.RoomId)
 
@@ -190,6 +208,9 @@ func TryRoomCommand(cmd string, rest string, userId int) (bool, error) {
 		)
 		vmw.VM.ClearInterrupt()
 		tmr.Stop()
+
+		userTextWrap.Reset()
+		roomTextWrap.Reset()
 
 		if err != nil {
 
@@ -214,6 +235,10 @@ func TryRoomCommand(cmd string, rest string, userId int) (bool, error) {
 
 	} else if onCommandFunc, ok := vmw.GetFunction(`onCommand`); ok {
 
+		// Set forced ansi tag wrappers
+		userTextWrap.Set(`script-text`, ``, ``)
+		roomTextWrap.Set(`script-text`, ``, ``)
+
 		sUser := GetUser(userId)
 		sRoom := GetRoom(user.Character.RoomId)
 
@@ -228,6 +253,9 @@ func TryRoomCommand(cmd string, rest string, userId int) (bool, error) {
 		)
 		vmw.VM.ClearInterrupt()
 		tmr.Stop()
+
+		userTextWrap.Reset()
+		roomTextWrap.Reset()
 
 		if err != nil {
 

--- a/internal/scripting/room_func.go
+++ b/internal/scripting/room_func.go
@@ -279,6 +279,10 @@ func (r ScriptRoom) RemoveTemporaryExit(exitNameSimple string, exitNameFancy str
 	return r.roomRecord.RemoveTemporaryExit(tmpExit)
 }
 
+func (r ScriptRoom) HasMutator(mutName string) bool {
+	return r.roomRecord.Mutators.Has(mutName)
+}
+
 func (r ScriptRoom) AddMutator(mutName string) {
 	r.roomRecord.Mutators.Add(mutName)
 }

--- a/internal/usercommands/admin.paz.go
+++ b/internal/usercommands/admin.paz.go
@@ -1,0 +1,60 @@
+package usercommands
+
+import (
+	"fmt"
+
+	"github.com/volte6/gomud/internal/colorpatterns"
+	"github.com/volte6/gomud/internal/mobs"
+	"github.com/volte6/gomud/internal/rooms"
+
+	"github.com/volte6/gomud/internal/users"
+)
+
+func Paz(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+
+	beamOfLight := colorpatterns.ApplyColorPattern(`beam of light`, `rainbow`)
+
+	if rest != `` {
+
+		playerId, mobId := room.FindByName(rest)
+
+		if mobId > 0 {
+
+			mob := mobs.GetInstance(mobId)
+			if mob == nil {
+				user.SendText("Paz Mob not found.")
+				return true, nil
+			}
+
+			user.SendText(fmt.Sprintf(`You illuminate <ansi fg="mobname">%s</ansi> with a %s!`, mob.Character.Name, beamOfLight))
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> illuminates <ansi fg="mobname">%s</ansi> with a %s!`, user.Character.Name, mob.Character.Name, beamOfLight), user.UserId)
+
+			mob.Character.Health = mob.Character.HealthMax.Value
+			mob.Character.Mana = mob.Character.ManaMax.Value
+
+			return true, nil
+		}
+
+		if playerId > 0 {
+			if u := users.GetByUserId(playerId); u != nil {
+				user.SendText(fmt.Sprintf(`You illuminate <ansi fg="username">%s</ansi> with a %s!`, u.Character.Name, beamOfLight))
+				room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> illuminates <ansi fg="username">%s</ansi> with a %s!`, user.Character.Name, u.Character.Name, beamOfLight), user.UserId, u.UserId)
+				u.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> illuminates you with a %s!`, user.Character.Name, beamOfLight))
+
+				u.Character.Health = u.Character.HealthMax.Value
+				u.Character.Mana = u.Character.ManaMax.Value
+
+				return true, nil
+			}
+		}
+
+	}
+
+	user.SendText(`You paz yourself with a ` + beamOfLight + `!`)
+	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> illuminates <ansi fg="username">%s</ansi> with a %s!`, user.Character.Name, user.Character.Name, beamOfLight), user.UserId)
+
+	user.Character.Health = user.Character.HealthMax.Value
+	user.Character.Mana = user.Character.ManaMax.Value
+
+	return true, nil
+}

--- a/internal/usercommands/admin.room.go
+++ b/internal/usercommands/admin.room.go
@@ -376,7 +376,7 @@ func Room(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 			}
 		} else {
-			user.SendText(fmt.Sprintf("Invalid room comand: %s", args[0]))
+			user.SendText(fmt.Sprintf("Invalid room command: %s", args[0]))
 		}
 	}
 

--- a/internal/usercommands/admin.zap.go
+++ b/internal/usercommands/admin.zap.go
@@ -50,22 +50,36 @@ func Zap(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	}
 
-	if user.Character.Aggro == nil || user.Character.Aggro.MobInstanceId == 0 {
+	if user.Character.Aggro == nil {
 		user.SendText("You are not in combat.")
 		return true, nil
 	}
 
-	mob := mobs.GetInstance(user.Character.Aggro.MobInstanceId)
-	if mob == nil {
-		user.SendText("Zap Mob not found.")
-		return true, nil
+	if user.Character.Aggro.MobInstanceId > 0 {
+		mob := mobs.GetInstance(user.Character.Aggro.MobInstanceId)
+		if mob == nil {
+			user.SendText("Zap Mob not found.")
+			return true, nil
+		} else {
+			user.SendText(fmt.Sprintf(`You zap <ansi fg="mobname">%s</ansi> with a %s!`, mob.Character.Name, boltOfLightning))
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a %s!`, user.Character.Name, mob.Character.Name, boltOfLightning), user.UserId)
+
+			mob.Character.Health = 1
+			mob.Character.Mana = 1
+		}
+	} else if user.Character.Aggro.UserId > 0 {
+		u := users.GetByUserId(user.Character.Aggro.UserId)
+		if u == nil {
+			user.SendText("Zap User not found.")
+			return true, nil
+		} else {
+			user.SendText(fmt.Sprintf(`You zap <ansi fg="username">%s</ansi> with a %s!`, u.Character.Name, boltOfLightning))
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="username">%s</ansi> with a %s!`, user.Character.Name, u.Character.Name, boltOfLightning), user.UserId)
+
+			u.Character.Health = 1
+			u.Character.Mana = 1
+		}
 	}
-
-	user.SendText(fmt.Sprintf(`You zap <ansi fg="mobname">%s</ansi> with a %s!`, mob.Character.Name, boltOfLightning))
-	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a %s!`, user.Character.Name, mob.Character.Name, boltOfLightning), user.UserId)
-
-	mob.Character.Health = 1
-	mob.Character.Mana = 1
 
 	return true, nil
 }

--- a/internal/usercommands/admin.zap.go
+++ b/internal/usercommands/admin.zap.go
@@ -3,6 +3,7 @@ package usercommands
 import (
 	"fmt"
 
+	"github.com/volte6/gomud/internal/colorpatterns"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/rooms"
 
@@ -10,6 +11,8 @@ import (
 )
 
 func Zap(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+
+	boltOfLightning := colorpatterns.ApplyColorPattern(`bolt of lightning`, `glowing`)
 
 	if rest != `` {
 
@@ -23,18 +26,24 @@ func Zap(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				return true, nil
 			}
 
-			user.SendText(fmt.Sprintf(`You zap <ansi fg="mobname">%s</ansi> with a bolt of lightning!`, mob.Character.Name))
-			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a bolt of lightning!`, user.Character.Name, mob.Character.Name), user.UserId)
+			user.SendText(fmt.Sprintf(`You zap <ansi fg="mobname">%s</ansi> with a %s!`, mob.Character.Name, boltOfLightning))
+			room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a %s!`, user.Character.Name, mob.Character.Name, boltOfLightning), user.UserId)
+
 			mob.Character.Health = 1
+			mob.Character.Mana = 1
+
 			return true, nil
 		}
 
 		if playerId > 0 {
 			if u := users.GetByUserId(playerId); u != nil {
-				user.SendText(fmt.Sprintf(`You zap <ansi fg="username">%s</ansi> with a bolt of lightning!`, u.Character.Name))
-				room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="username">%s</ansi> with a bolt of lightning!`, user.Character.Name, u.Character.Name), user.UserId, u.UserId)
-				u.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps you with a bolt of lightning!`, user.Character.Name))
+				user.SendText(fmt.Sprintf(`You zap <ansi fg="username">%s</ansi> with a %s!`, u.Character.Name, boltOfLightning))
+				room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="username">%s</ansi> with a %s!`, user.Character.Name, u.Character.Name, boltOfLightning), user.UserId, u.UserId)
+				u.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps you with a %s!`, user.Character.Name, boltOfLightning))
+
 				u.Character.Health = 1
+				u.Character.Mana = 1
+
 				return true, nil
 			}
 		}
@@ -52,9 +61,11 @@ func Zap(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 		return true, nil
 	}
 
-	user.SendText(fmt.Sprintf(`You zap <ansi fg="mobname">%s</ansi> with a bolt of lightning!`, mob.Character.Name))
-	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a bolt of lightning!`, user.Character.Name, mob.Character.Name), user.UserId)
+	user.SendText(fmt.Sprintf(`You zap <ansi fg="mobname">%s</ansi> with a %s!`, mob.Character.Name, boltOfLightning))
+	room.SendText(fmt.Sprintf(`<ansi fg="username">%s</ansi> zaps <ansi fg="mobname">%s</ansi> with a %s!`, user.Character.Name, mob.Character.Name, boltOfLightning), user.UserId)
+
 	mob.Character.Health = 1
+	mob.Character.Mana = 1
 
 	return true, nil
 }

--- a/internal/usercommands/start.go
+++ b/internal/usercommands/start.go
@@ -177,6 +177,8 @@ func Start(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 		user.SendText(fmt.Sprintf(`You will be known as <ansi fg="yellow-bold">%s</ansi>!%s`, user.Character.Name, term.CRLFStr))
 	}
 
+	user.Character.ExtraLives = int(configs.GetConfig().LivesStart)
+
 	user.EventLog.Add(`char`, fmt.Sprintf(`Created a new character: <ansi fg="username">%s</ansi>`, user.Character.Name))
 
 	user.SendText(fmt.Sprintf(`<ansi fg="magenta">Suddenly, a vortex appears before you, drawing you in before you have any chance to react!</ansi>%s`, term.CRLFStr))

--- a/world.go
+++ b/world.go
@@ -1426,7 +1426,7 @@ func (w *World) TurnTick() {
 					continue
 				}
 
-				mob.DamageTaken[sourceUser.UserId] = 0 // Take note that the player did damage this mob.
+				mob.Character.TrackPlayerDamage(sourceUser.UserId, 0)
 
 				if sourceUser.Character.RoomId == mob.Character.RoomId {
 					// Mobs get aggro when attacked

--- a/world.roundtick.go
+++ b/world.roundtick.go
@@ -543,6 +543,12 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 			continue
 		}
 
+		/**************************
+		*
+		* START HANDLING MAGIC
+		*
+		**************************/
+
 		if user.Character.Aggro != nil && user.Character.Aggro.Type == characters.SpellCast {
 
 			if user.Character.Aggro.RoundsWaiting > 0 {
@@ -574,10 +580,7 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 				if defMob := mobs.GetInstance(mInstId); defMob != nil {
 
 					// Remember who has hit him
-					if _, ok := defMob.DamageTaken[user.UserId]; !ok {
-						defMob.DamageTaken[user.UserId] = 0
-					}
-
+					defMob.Character.TrackPlayerDamage(user.UserId, 0)
 					mobHealthBefore[mInstId] = defMob.Character.Health
 
 				}
@@ -607,7 +610,7 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 								if hBefore, ok := mobHealthBefore[mobId]; ok {
 									hDelta := hBefore - defMob.Character.Health
 									if hDelta > 0 {
-										defMob.DamageTaken[user.UserId] = defMob.DamageTaken[user.UserId] + hDelta
+										defMob.Character.TrackPlayerDamage(user.UserId, hDelta)
 									}
 								}
 
@@ -632,6 +635,18 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 			continue
 
 		}
+
+		/**************************
+		*
+		* END HANDLING MAGIC
+		*
+		**************************/
+
+		/**************************
+		*
+		* START HANDLING PHYSICAL COMBAT
+		*
+		**************************/
 
 		// In combat with another player
 		if user.Character.Aggro != nil && user.Character.Aggro.UserId > 0 {
@@ -778,6 +793,9 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 
 			// If the attack connected, check for damage to equipment.
 			if roundResult.Hit {
+
+				defUser.Character.TrackPlayerDamage(user.UserId, roundResult.DamageToTarget)
+
 				// For now, only focus on offhand items.
 				if defUser.Character.Equipment.Offhand.ItemId > 0 {
 
@@ -971,6 +989,12 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 
 		}
 
+		/**************************
+		*
+		* END HANDLING PHYSICAL COMBAT
+		*
+		**************************/
+
 	}
 
 	util.TrackTime(`World::handlePlayerCombat()`, time.Since(tStart).Seconds())
@@ -1009,6 +1033,12 @@ func (w *World) handleMobCombat() (affectedPlayerIds []int, affectedMobInstanceI
 
 		// Disable any buffs that are cancelled by combat
 		mob.Character.CancelBuffsWithFlag(buffs.CancelIfCombat)
+
+		/**************************
+		*
+		* START HANDLING MAGIC
+		*
+		**************************/
 
 		if mob.Character.Aggro != nil && mob.Character.Aggro.Type == characters.SpellCast {
 
@@ -1070,6 +1100,18 @@ func (w *World) handleMobCombat() (affectedPlayerIds []int, affectedMobInstanceI
 			continue
 
 		}
+
+		/**************************
+		*
+		* END HANDLING MAGIC
+		*
+		**************************/
+
+		/**************************
+		*
+		* START HANDLING PHYSICAL COMBAT
+		*
+		**************************/
 
 		// H2H is the base level combat, can do combat commands then
 		if mob.Character.Aggro.Type == characters.DefaultAttack {
@@ -1392,6 +1434,12 @@ func (w *World) handleMobCombat() (affectedPlayerIds []int, affectedMobInstanceI
 			}
 
 		}
+
+		/**************************
+		*
+		* END HANDLING PHYSICAL COMBAT
+		*
+		**************************/
 
 	}
 


### PR DESCRIPTION
# Changes
* Added stormshards content (push boulder), to be expanded upon later (tests ephemeral mutator exit via scripting)
* Updated room scripting: `room.HasMutator()`
* Added `paz` command (inverse of `zap`) to quick recover hp/mp.
* Added better color style to `zap`/`paz`
* Fixed spellcasting bug where it would assuming player was trying to `go` when in combat and reject.
* Improved magic combat tracking for experience gains and mob death.
* Added keywords for targeting self in commands: `self`, `myself`, `me`
  * Currently only applies to commands where the END of the command is the target name. May not apply to all cases (unsure)
  * Example: `look at self`, `look at me`, `give potion to myself` etc., useful when targeting for spells or admin commands.
 * Added default color for room script output text (ansi color class `script-text`)
 * Added PVP to `killstats`
 * Fixed starting lives for characters after permadeath
 * Better tracking of mob vs player damage, reporting of who killed players.