### PR TITLE
PVP Config, measuring tool, sparks spell

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -83,9 +83,13 @@ AuctionSeconds: 180
 # - AuctionUpdateSeconds -
 #   How may seconds (roughly) between updates on current auction.
 AuctionUpdateSeconds: 30
-# - PVPEnabled -
-#   If true, players can attack each other. If false, they cannot.
-PVPEnabled: true
+# - PVP -
+#   Possible Values:
+#     enabled   - PVP is enabled everywhere
+#     disabled  - PVP is disabled eveywhere
+#     voluntary - PVP is enabled everywhere for players that enable it
+#     limited   - PVP is enabled for all players but only in PVP enabled rooms
+PVP: enabled
 # - XPScale -
 #   Scales XP Charts for character leveling. Lower means less required, higher
 #   means more required. 1 is the default (no change).
@@ -368,7 +372,7 @@ BannedNames:
 #   update this to a large number (like 100000), so that as new rooms are 
 #   created they will be far beyond the range of any room id's expected through
 #   a code update.
-NextRoomId: 1001
+NextRoomId: 1002
 # - LogIntervalRoundCount - 
 #   How often to log the round count. Can help judge logs a little better.
 LogIntervalRoundCount: 1

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -87,9 +87,8 @@ AuctionUpdateSeconds: 30
 #   Possible Values:
 #     enabled   - PVP is enabled everywhere
 #     disabled  - PVP is disabled eveywhere
-#     voluntary - PVP is enabled everywhere for players that enable it
 #     limited   - PVP is enabled for all players but only in PVP enabled rooms
-PVP: enabled
+PVP: limited
 # - XPScale -
 #   Scales XP Charts for character leveling. Lower means less required, higher
 #   means more required. 1 is the default (no change).

--- a/_datafiles/mutators/pvp_enabled.yaml
+++ b/_datafiles/mutators/pvp_enabled.yaml
@@ -1,0 +1,3 @@
+mutatorid: pvp-enabled
+pvp:
+  enabled: true

--- a/_datafiles/rooms/frostfang_slums/439.yaml
+++ b/_datafiles/rooms/frostfang_slums/439.yaml
@@ -5,6 +5,8 @@ zoneconfig:
   autoscale:
     minimum: 5
     maximum: 10
+  mutators:
+  - mutatorid: pvp-enabled
 title: Poorly Lit Street
 description: 'Tucked away in the heart of Frostfang''s sprawling slums, a dimly lit
   alleyway meanders from the bustling Beggars Lane. This concealed corner, a world

--- a/_datafiles/spells/sparks.js
+++ b/_datafiles/spells/sparks.js
@@ -1,0 +1,61 @@
+
+DMG_DICE_QTY = 1
+DMG_DICE_SIDES = 3
+
+// Called when the casting is initialized (cast command)
+// Return false if the casting should be ignored/aborted
+function onCast(sourceActor, targetActors) {
+
+    SendUserMessage(sourceActor.UserId(), 'You begin to chant softly.');
+    SendRoomMessage(sourceActor.GetRoomId(), sourceActor.GetCharacterName(true)+' begins to chant softly.', sourceActor.UserId());
+    return true
+}
+
+function onWait(sourceActor, targetActors) {
+
+    SendUserMessage(sourceActor.UserId(), 'You continue chanting...');
+    SendRoomMessage(sourceActor.GetRoomId(), sourceActor.GetCharacterName(true)+' continues chanting...', sourceActor.UserId());
+}
+
+// Called when the spell succeeds its cast attempt
+function onMagic(sourceActor, targetActors) {
+
+    roomId = sourceActor.GetRoomId();
+
+    sourceUserId = sourceActor.UserId();
+    sourceName = sourceActor.GetCharacterName(true);
+
+    for (var i = 0; i < targetActors.length; i++) {
+        
+        dmgAmt = UtilDiceRoll(DMG_DICE_QTY, DMG_DICE_SIDES) + 1;
+        dmgAmtStr = String(dmgAmt);
+
+        targetUserId = targetActors[i].UserId();
+        targetName = targetActors[i].GetCharacterName(true);
+
+        if ( sourceActor.UserId() != targetActors[i].UserId() ) {
+
+            // Tell the caster about the action
+            SendUserMessage(sourceUserId, 'You let loose a shower of sparks that hit '+targetName+', doing <ansi fg="damage">'+dmgAmtStr+' damage</ansi>.');
+
+            // Tell the room about the dmg, except the source and target
+            SendRoomMessage(roomId, sourceName+' stops chanting and lets loose a shower of sparks, hitting '+targetName+'.', sourceUserId, targetUserId);
+
+            // Tell the target about the dmg
+            SendUserMessage(targetUserId, sourceName+' stops chanting fires a shower of sparks at you, hitting for <ansi fg="damage">'+dmgAmtStr+' damage</ansi>.');
+
+        } else {
+
+            // Tell the cast they did it to themselves
+            SendUserMessage(sourceUserId, 'You stop chanting and fires a shower of sparks at yourself, doing <ansi fg="damage">'+dmgAmtStr+' damage</ansi>.');
+
+            // Tell the room about the dmg, except the source and target
+            SendRoomMessage(roomId, sourceName+' stops chanting and fires a shower of sparks at themselves, hurting themselves.', sourceUserId, targetUserId);
+
+        }
+
+        // Apply the dmg to the target
+        targetActors[i].AddHealth(dmgAmt * -1);
+    }
+    
+}

--- a/_datafiles/spells/sparks.yaml
+++ b/_datafiles/spells/sparks.yaml
@@ -1,0 +1,8 @@
+spellid: sparks
+name: Shower of Sparks
+description: Hurts for 1d3+1
+type: harmmulti
+school: conjuration
+cost: 10
+waitrounds: 1
+difficulty: 50

--- a/_datafiles/templates/descriptions/room-title.template
+++ b/_datafiles/templates/descriptions/room-title.template
@@ -2,4 +2,4 @@
 {{ if ne .RoomSymbol "" -}}
    {{ $mapSymbol = printf `<ansi fg="black-bold">[</ansi><ansi fg="map-%s">%s</ansi><ansi fg="black-bold">]</ansi> ` (lowercase .RoomLegend) .RoomSymbol }}
 {{- end }}
-<ansi fg="black-bold">.:</ansi> {{ $mapSymbol }}{{ if .IsBurning }}{{ colorpattern .Title "flame" }}{{ else }}<ansi fg="room-title">{{ .Title }}</ansi>{{ end }}{{ if ne .Zone ""}} <ansi fg="room-zone">[{{ .Zone }}]</ansi>{{ end }}
+<ansi fg="black-bold">.:</ansi> {{ $mapSymbol }}{{ if .IsBurning }}{{ colorpattern .Title "flame" }}{{ else }}<ansi fg="room-title">{{ .Title }}</ansi>{{ end }}{{ if ne .Zone ""}} <ansi fg="room-zone">[{{ .Zone }}]</ansi>{{ end }}{{ if .ShowPvp }} <ansi fg="11" bg="52"> ☠ PK Area ☠ </ansi>{{ end }}

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -386,7 +386,7 @@ func (c *Config) Validate() {
 	}
 
 	// Validate PVP setting
-	if c.PVP != `enabled` && c.PVP != `disabled` {
+	if c.PVP != `enabled` && c.PVP != `disabled` && c.PVP != `limited` {
 		if c.PVP == `off` {
 			c.PVP = `disabled`
 		} else {

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -33,7 +33,7 @@ type Config struct {
 	AuctionsAnonymous            ConfigBool        `yaml:"AuctionsAnonymous"`
 	AuctionSeconds               ConfigInt         `yaml:"AuctionSeconds"`
 	AuctionUpdateSeconds         ConfigInt         `yaml:"AuctionUpdateSeconds"`
-	PVPEnabled                   ConfigBool        `yaml:"PVPEnabled"`
+	PVP                          ConfigString      `yaml:"PVP"`
 	XPScale                      ConfigFloat       `yaml:"XPScale"`
 	TurnMs                       ConfigInt         `yaml:"TurnMs"`
 	RoundSeconds                 ConfigInt         `yaml:"RoundSeconds"`
@@ -385,7 +385,14 @@ func (c *Config) Validate() {
 		c.AuctionUpdateSeconds = c.AuctionSeconds >> 1 // default
 	}
 
-	// Nothing to do with PVPEnabled
+	// Validate PVP setting
+	if c.PVP != `enabled` && c.PVP != `disabled` {
+		if c.PVP == `off` {
+			c.PVP = `disabled`
+		} else {
+			c.PVP = `enabled`
+		}
+	}
 
 	if c.XPScale <= 0 {
 		c.XPScale = 1.0 // default

--- a/internal/mutators/mutators.go
+++ b/internal/mutators/mutators.go
@@ -49,6 +49,11 @@ type TextModifier struct {
 	ColorPattern string       `yaml:"colorpattern,omitempty"` // An optional color pattern name to apply
 }
 
+type PvpOverride struct {
+	Enabled  bool `yaml:"enabled,omitempty"`  // force enabled?
+	Disabled bool `yaml:"disabled,omitempty"` // force disabled?
+}
+
 type MutatorSpec struct {
 	MutatorId string `yaml:"mutatorid,omitempty"` // Short text that will uniquely identify this modifier ("dusty")
 	// Text based changes
@@ -64,6 +69,7 @@ type MutatorSpec struct {
 	RespawnRate   string                   `yaml:"respawnrate,omitempty"`   // daily, weekly, 1 day, 3 day, monthly, etc.
 	LightMod      int                      `yaml:"lightmod,omitempty"`      //  -2 to 2 (change). If result is 0 = none. 1 = can see this room. 2 = can see this room and all exits
 	Exits         map[string]exit.RoomExit `yaml:"exits,omitempty"`         // name/roomId pairs of exits only available while mutator is live.
+	Pvp           PvpOverride              `yaml:"pvp,omitempty"`           // optionally force room pvp attributes.
 }
 
 func GetAllMutatorSpecs() []MutatorSpec {

--- a/internal/rooms/roomdetails.go
+++ b/internal/rooms/roomdetails.go
@@ -7,6 +7,7 @@ import (
 	"github.com/volte6/gomud/internal/buffs"
 	"github.com/volte6/gomud/internal/characters"
 	"github.com/volte6/gomud/internal/colorpatterns"
+	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/events"
 	"github.com/volte6/gomud/internal/exit"
 	"github.com/volte6/gomud/internal/gametime"
@@ -37,9 +38,12 @@ type RoomTemplateDetails struct {
 	IsBurning      bool
 	TrackingString string
 	RoomAlerts     []string // Messages to show below room description as a special alert
+	ShowPvp        bool     // Whether to display that the room is PVP
 }
 
 func GetDetails(r *Room, user *users.UserRecord) RoomTemplateDetails {
+
+	c := configs.GetConfig()
 
 	var roomSymbol string = r.MapSymbol
 	var roomLegend string = r.MapLegend
@@ -51,6 +55,12 @@ func GetDetails(r *Room, user *users.UserRecord) RoomTemplateDetails {
 	}
 	if b.name != `` {
 		roomLegend = b.name
+	}
+
+	showPvp := false
+	// Don't need to show the PVP flag if Pvp is globally enabled or globally disabled
+	if c.PVP == `limited` {
+		showPvp = r.IsPvp()
 	}
 
 	details := RoomTemplateDetails{
@@ -70,6 +80,7 @@ func GetDetails(r *Room, user *users.UserRecord) RoomTemplateDetails {
 		IsNight:        gametime.IsNight(),
 		IsBurning:      r.IsBurning(),
 		TrackingString: ``,
+		ShowPvp:        showPvp,
 	}
 
 	//

--- a/internal/usercommands/ask.go
+++ b/internal/usercommands/ask.go
@@ -104,7 +104,7 @@ func Ask(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 			if mobCmd == `attack` {
 				if pid, _ := room.FindByName(askRest); pid > 0 {
-					if !configs.GetConfig().PVPEnabled {
+					if configs.GetConfig().PVP != `enabled` {
 
 						mob.Command(`emote shakes their head.`)
 						mob.Command(`say PVP is currently disabled.`)

--- a/internal/usercommands/attack.go
+++ b/internal/usercommands/attack.go
@@ -163,7 +163,7 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 	} else if attackPlayerId > 0 {
 
-		if !configs.GetConfig().PVPEnabled {
+		if configs.GetConfig().PVP != `enabled` {
 			user.SendText(`PVP is currently disabled.`)
 			return true, nil
 		}

--- a/internal/usercommands/attack.go
+++ b/internal/usercommands/attack.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/volte6/gomud/internal/buffs"
 	"github.com/volte6/gomud/internal/characters"
-	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/parties"
 	"github.com/volte6/gomud/internal/rooms"
@@ -163,14 +162,12 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 	} else if attackPlayerId > 0 {
 
-		if configs.GetConfig().PVP != `enabled` {
-			user.SendText(`PVP is currently disabled.`)
-			return true, nil
-		}
+		if p := users.GetByUserId(attackPlayerId); p != nil {
 
-		p := users.GetByUserId(attackPlayerId)
-
-		if p != nil {
+			if pvpErr := room.CanPvp(user, p); pvpErr != nil {
+				user.SendText(pvpErr.Error())
+				return true, nil
+			}
 
 			if partyInfo := parties.Get(user.UserId); partyInfo != nil {
 				if partyInfo.IsMember(attackPlayerId) {

--- a/internal/usercommands/print.go
+++ b/internal/usercommands/print.go
@@ -1,17 +1,61 @@
 package usercommands
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/volte6/gomud/internal/events"
 	"github.com/volte6/gomud/internal/rooms"
 	"github.com/volte6/gomud/internal/users"
 )
 
+// Prints message to screen
 func Print(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	events.AddToQueue(events.Message{
 		UserId: user.UserId,
 		Text:   rest,
 	})
+
+	return true, nil
+}
+
+// PrintLine (command `printline`) is just a simple measuring tool/ruler for layout purposes
+func PrintLine(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+
+	sectionSize := 20
+
+	lineLength, _ := strconv.Atoi(rest)
+	if lineLength > 0 {
+		if lineLength > 240 {
+			lineLength = 240
+		}
+
+		sections := lineLength / sectionSize
+
+		finalOutput := ``
+
+		for i := 0; i < sections; i++ {
+			sectionStr := ``
+
+			sectionStr += strings.Repeat(`=`, sectionSize)
+			countStr := fmt.Sprintf(` %d |`, (i+1)*sectionSize)
+			sectionStr = sectionStr[:sectionSize-len(countStr)] + countStr
+
+			finalOutput += sectionStr
+		}
+
+		remaining := lineLength - len(finalOutput)
+
+		if remaining > 0 {
+			finalOutput += strings.Repeat(`=`, remaining)
+			finalOutput = finalOutput[:len(finalOutput)-1] + `|`
+		}
+
+		finalOutput = strings.ReplaceAll(finalOutput, `=`, `<ansi fg="8">=</ansi>`)
+		user.SendText(finalOutput)
+	}
 
 	return true, nil
 }

--- a/internal/usercommands/skill.brawling.throw.go
+++ b/internal/usercommands/skill.brawling.throw.go
@@ -101,6 +101,11 @@ func Throw(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 
 	} else if targetPlayerId > 0 {
 
+		if configs.GetConfig().PVP != `enabled` {
+			user.SendText(`PVP is currently disabled.`)
+			return true, nil
+		}
+
 		targetUser := users.GetByUserId(targetPlayerId)
 
 		user.Character.RemoveItem(itemMatch)

--- a/internal/usercommands/skill.brawling.throw.go
+++ b/internal/usercommands/skill.brawling.throw.go
@@ -101,12 +101,12 @@ func Throw(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 
 	} else if targetPlayerId > 0 {
 
-		if configs.GetConfig().PVP != `enabled` {
-			user.SendText(`PVP is currently disabled.`)
+		targetUser := users.GetByUserId(targetPlayerId)
+
+		if pvpErr := room.CanPvp(user, targetUser); pvpErr != nil {
+			user.SendText(pvpErr.Error())
 			return true, nil
 		}
-
-		targetUser := users.GetByUserId(targetPlayerId)
 
 		user.Character.RemoveItem(itemMatch)
 

--- a/internal/usercommands/skill.skulduggery.backstab.go
+++ b/internal/usercommands/skill.skulduggery.backstab.go
@@ -112,7 +112,7 @@ func Backstab(rest string, user *users.UserRecord, room *rooms.Room) (bool, erro
 
 	} else if attackPlayerId > 0 {
 
-		if !configs.GetConfig().PVPEnabled {
+		if configs.GetConfig().PVP != `enabled` {
 			user.SendText(`PVP is currently disabled.`)
 			return true, nil
 		}

--- a/internal/usercommands/skill.skulduggery.backstab.go
+++ b/internal/usercommands/skill.skulduggery.backstab.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/volte6/gomud/internal/buffs"
 	"github.com/volte6/gomud/internal/characters"
-	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/items"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/parties"
@@ -112,14 +111,12 @@ func Backstab(rest string, user *users.UserRecord, room *rooms.Room) (bool, erro
 
 	} else if attackPlayerId > 0 {
 
-		if configs.GetConfig().PVP != `enabled` {
-			user.SendText(`PVP is currently disabled.`)
-			return true, nil
-		}
+		if p := users.GetByUserId(attackPlayerId); p != nil {
 
-		p := users.GetByUserId(attackPlayerId)
-
-		if p != nil {
+			if pvpErr := room.CanPvp(user, p); pvpErr != nil {
+				user.SendText(pvpErr.Error())
+				return true, nil
+			}
 
 			if partyInfo := parties.Get(user.UserId); partyInfo != nil {
 				if partyInfo.IsMember(attackPlayerId) {

--- a/internal/usercommands/skill.skulduggery.bump.go
+++ b/internal/usercommands/skill.skulduggery.bump.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/volte6/gomud/internal/buffs"
+	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/rooms"
 	"github.com/volte6/gomud/internal/skills"
@@ -100,6 +101,11 @@ func Bump(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 		}
 
 	} else if pickPlayerId > 0 {
+
+		if configs.GetConfig().PVP != `enabled` {
+			user.SendText(`PVP is currently disabled.`)
+			return true, nil
+		}
 
 		p := users.GetByUserId(pickPlayerId)
 

--- a/internal/usercommands/skill.skulduggery.bump.go
+++ b/internal/usercommands/skill.skulduggery.bump.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/volte6/gomud/internal/buffs"
-	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/rooms"
 	"github.com/volte6/gomud/internal/skills"
@@ -102,14 +101,12 @@ func Bump(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	} else if pickPlayerId > 0 {
 
-		if configs.GetConfig().PVP != `enabled` {
-			user.SendText(`PVP is currently disabled.`)
-			return true, nil
-		}
+		if p := users.GetByUserId(pickPlayerId); p != nil {
 
-		p := users.GetByUserId(pickPlayerId)
-
-		if p != nil {
+			if pvpErr := room.CanPvp(user, p); pvpErr != nil {
+				user.SendText(pvpErr.Error())
+				return true, nil
+			}
 
 			levelDelta := user.Character.Level - p.Character.Level
 			if levelDelta < 1 {

--- a/internal/usercommands/skill.skulduggery.pickpocket.go
+++ b/internal/usercommands/skill.skulduggery.pickpocket.go
@@ -132,7 +132,7 @@ func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room) (bool, er
 
 	} else if pickPlayerId > 0 {
 
-		if !configs.GetConfig().PVPEnabled {
+		if configs.GetConfig().PVP != `enabled` {
 			user.SendText(`PVP is currently disabled.`)
 			return true, nil
 		}

--- a/internal/usercommands/skill.skulduggery.pickpocket.go
+++ b/internal/usercommands/skill.skulduggery.pickpocket.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/volte6/gomud/internal/buffs"
-	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/events"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/rooms"
@@ -132,14 +131,12 @@ func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room) (bool, er
 
 	} else if pickPlayerId > 0 {
 
-		if configs.GetConfig().PVP != `enabled` {
-			user.SendText(`PVP is currently disabled.`)
-			return true, nil
-		}
+		if p := users.GetByUserId(pickPlayerId); p != nil {
 
-		p := users.GetByUserId(pickPlayerId)
-
-		if p != nil {
+			if pvpErr := room.CanPvp(user, p); pvpErr != nil {
+				user.SendText(pvpErr.Error())
+				return true, nil
+			}
 
 			levelDelta := user.Character.Level - p.Character.Level
 			if levelDelta < 1 {

--- a/internal/usercommands/spells.go
+++ b/internal/usercommands/spells.go
@@ -88,7 +88,7 @@ func Spells(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 		if len(rows) > 0 {
 			rowFormatting = append(rowFormatting, []string{`%s`, `%s`, `%s`, `%s`, `%s`, `%s`, `%s`, `%s`})
-			rows = append(rows, []string{``, ``, ``, ``, ``, ``, ``, ``})
+			rows = append(rows, []string{`-`, ``, ``, ``, ``, ``, ``, ``})
 		}
 
 		for i := 0; i < len(harmfulRows); i++ {
@@ -101,7 +101,7 @@ func Spells(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 		if len(rows) > 0 {
 			rowFormatting = append(rowFormatting, []string{`%s`, `%s`, `%s`, `%s`, `%s`, `%s`, `%s`, `%s`})
-			rows = append(rows, []string{``, ``, ``, ``, ``, ``, ``, ``})
+			rows = append(rows, []string{`-`, ``, ``, ``, ``, ``, ``, ``})
 		}
 
 		for i := 0; i < len(neutralRows); i++ {

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -102,6 +102,7 @@ var (
 		`portal`:      {Portal, false, false},
 		`pray`:        {Pray, false, false},
 		`print`:       {Print, true, false},
+		`printline`:   {PrintLine, true, false},
 		`put`:         {Put, false, false},
 		`quests`:      {Quests, true, false},
 		`quit`:        {Quit, true, false},

--- a/world.go
+++ b/world.go
@@ -1387,7 +1387,14 @@ func (w *World) TurnTick() {
 			})
 
 			if hitPlayers {
+
 				for _, uid := range room.GetPlayers() {
+
+					// If not hitting self and pvp is disabled, skip
+					if action.SourceUserId > 0 && action.SourceUserId != uid && configs.GetConfig().PVP != `enabled` {
+						continue
+					}
+
 					for _, buffId := range iSpec.BuffIds {
 						events.AddToQueue(events.Buff{
 							UserId:        uid,
@@ -1396,6 +1403,7 @@ func (w *World) TurnTick() {
 						})
 					}
 				}
+
 			}
 
 			if !hitMobs {


### PR DESCRIPTION
# Changes
* Adjusting pvp config value to a string:
  * `enabled` - PVP is allowed everywhere.
  * `disabled` - PVP is never allowed.
  * `limited` (default) - PVP is allowed in designated areas
* Rooms have a property `pvp` which can be set true to allow a specific room to be pvp-enabled.
* Mutators have a `pvp` property which can be set: `pvp.enabled` or `pvp.disabled` to override/force pvp to a specific on/off state in a room.
  * Added a `pvp-enabled` mutator that demonstrates enabling pvp via mutator, and applied it to the entire frostfang slums area.
  * Added a `sparks` spell to test harmful spells that target groups

Example PVP warning:

<img width="687" alt="image" src="https://github.com/user-attachments/assets/b6e8bec8-ca3f-49ff-b3b6-dd8b94c570fe">
