### PR TITLE
Support for shop item trade-ins. Fixing padding in shop table

### DIFF
--- a/_datafiles/templates/tables/shoplist.template
+++ b/_datafiles/templates/tables/shoplist.template
@@ -1,5 +1,6 @@
 
 {{ $columnWidths := .ColumnWidths -}}
+{{- $tableData := . }}
 {{- $headers := .Header -}}
 {{- $padding := 1 -}}
 <ansi fg="black-bold">.:</ansi> <ansi fg="table-title">{{ .Title }}</ansi>
@@ -7,5 +8,5 @@
 {{ range $i, $col := .Header }}│<ansi fg="white">{{ repeat " " $padding }}{{ printf "%-*s" (index $columnWidths $i) $col }}{{ repeat " " $padding }}</ansi>{{ end }}│
 └{{ range $i, $w := $columnWidths }}{{ repeat "─" $padding }}{{ repeat "─" $w }}{{ repeat "─" $padding }}┘{{ end }}
 {{ range $rowIndex, $row := .Rows }}
-{{- range $i, $col := $row }}│<ansi fg="shop-{{ lowercase (index $headers $i) }}">{{ repeat " " $padding }}{{ printf "%-*s" (index $columnWidths $i) $col }}{{ repeat " " $padding }}</ansi>{{ end }}│
+{{- range $i, $col := $row }}│<ansi fg="shop-{{ lowercase (index $headers $i) }}">{{ repeat " " $padding }}{{ printf "%-*s" (index $columnWidths $i) ($tableData.GetCell $rowIndex $i) }}{{ repeat " " $padding }}</ansi>{{ end }}│
 {{ end }}└{{ range $i, $w := $columnWidths }}{{ repeat "─" $padding }}{{ repeat "─" $w }}{{ repeat "─" $padding }}┘{{ end }}</ansi>

--- a/internal/characters/shop.go
+++ b/internal/characters/shop.go
@@ -21,6 +21,7 @@ type ShopItem struct {
 	Quantity    int    `yaml:"quantity,omitempty"`    // How many currently avilable
 	QuantityMax int    `yaml:"quantitymax,omitempty"` // 0 for unlimited, or a maximum that can be stocked at one time
 	Price       int    `yaml:"price,omitempty"`       // If a price is provided, use it
+	TradeItemId int    `yaml:"tradeitemid,omitempty"` // ItemId required in trade
 	RestockRate string `yaml:"restockrate,omitempty"` // 1 day, 1 week, 1 real month, etc
 
 	lastRestockRound uint64 // When was the last time an item was restocked?

--- a/internal/usercommands/list.go
+++ b/internal/usercommands/list.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/volte6/gomud/internal/buffs"
 	"github.com/volte6/gomud/internal/characters"
@@ -69,7 +68,18 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 		if len(itemsAvailable) > 0 {
 
+			hasTradeItems := false
+			for _, stockItm := range itemsAvailable {
+				if stockItm.TradeItemId > 0 {
+					hasTradeItems = true
+				}
+			}
+
 			headers := []string{"Qty", "Name", "Type", "Price"}
+			if hasTradeItems {
+				headers = append(headers, "Trade")
+			}
+
 			rows := [][]string{}
 
 			for _, stockItm := range itemsAvailable {
@@ -83,14 +93,27 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				price := stockItm.Price
 				if price == 0 {
 					price = item.GetSpec().Value
+				} else if price < 0 {
+					price = 0
 				}
 
-				rows = append(rows, []string{
+				entryRow := []string{
 					qtyStr,
-					fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, item.DisplayName()) + strings.Repeat(" ", 30-len(item.Name())),
+					fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, item.DisplayName()),
 					string(item.GetSpec().Type),
-					strconv.Itoa(price)},
-				)
+					strconv.Itoa(price),
+				}
+
+				if hasTradeItems {
+					if stockItm.TradeItemId > 0 {
+						tradeItm := items.New(stockItm.TradeItemId)
+						entryRow = append(entryRow, fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, tradeItm.DisplayName()))
+					} else {
+						entryRow = append(entryRow, ``)
+					}
+				}
+
+				rows = append(rows, entryRow)
 			}
 
 			sort.Slice(rows, func(i, j int) bool {
@@ -107,7 +130,18 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 		if len(mercsAvailable) > 0 {
 
+			hasTradeItems := false
+			for _, stockItm := range mercsAvailable {
+				if stockItm.TradeItemId > 0 {
+					hasTradeItems = true
+				}
+			}
+
 			headers := []string{"Qty", "Name", "Level", "Race", "Price"}
+
+			if hasTradeItems {
+				headers = append(headers, "Trade")
+			}
 
 			rows := [][]string{}
 
@@ -130,15 +164,28 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				price := stockMerc.Price
 				if price == 0 {
 					price = 250 * mobInfo.Character.Level
+				} else if price < 0 {
+					price = 0
 				}
 
-				rows = append(rows, []string{
+				entryRow := []string{
 					qtyStr,
-					`<ansi fg="mobname">` + mobInfo.Character.Name + `</ansi>` + strings.Repeat(" ", 30-len(mobInfo.Character.Name)),
+					`<ansi fg="mobname">` + mobInfo.Character.Name + `</ansi>`,
 					strconv.Itoa(mobInfo.Character.Level),
 					raceInfo.Name,
 					strconv.Itoa(price),
-				})
+				}
+
+				if hasTradeItems {
+					if stockMerc.TradeItemId > 0 {
+						tradeItm := items.New(stockMerc.TradeItemId)
+						entryRow = append(entryRow, fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, tradeItm.DisplayName()))
+					} else {
+						entryRow = append(entryRow, ``)
+					}
+				}
+
+				rows = append(rows, entryRow)
 
 			}
 
@@ -156,7 +203,18 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 		if len(buffsAvailable) > 0 {
 
+			hasTradeItems := false
+			for _, stockItm := range buffsAvailable {
+				if stockItm.TradeItemId > 0 {
+					hasTradeItems = true
+				}
+			}
+
 			headers := []string{"Qty", "Name", "Price"}
+			if hasTradeItems {
+				headers = append(headers, "Trade")
+			}
+
 			rows := [][]string{}
 
 			for _, stockBuff := range buffsAvailable {
@@ -171,11 +229,23 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 					qtyStr = strconv.Itoa(stockBuff.Quantity)
 				}
 
-				rows = append(rows, []string{
+				entryRow := []string{
 					qtyStr,
-					buffInfo.Name + strings.Repeat(" ", 30-len(buffInfo.Name)),
-					strconv.Itoa(stockBuff.Price)},
-				)
+					buffInfo.Name,
+					strconv.Itoa(stockBuff.Price),
+				}
+
+				if hasTradeItems {
+					if stockBuff.TradeItemId > 0 {
+						tradeItm := items.New(stockBuff.TradeItemId)
+						entryRow = append(entryRow, fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, tradeItm.DisplayName()))
+					} else {
+						entryRow = append(entryRow, ``)
+					}
+				}
+
+				rows = append(rows, entryRow)
+
 			}
 
 			sort.Slice(rows, func(i, j int) bool {
@@ -192,7 +262,18 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 		if len(petsAvailable) > 0 {
 
+			hasTradeItems := false
+			for _, stockItm := range petsAvailable {
+				if stockItm.TradeItemId > 0 {
+					hasTradeItems = true
+				}
+			}
+
 			headers := []string{"Qty", "Type", "Price"}
+			if hasTradeItems {
+				headers = append(headers, "Trade")
+			}
+
 			rows := [][]string{}
 
 			for _, stockPet := range petsAvailable {
@@ -210,13 +291,26 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				price := stockPet.Price
 				if price == 0 {
 					price = 10000
+				} else if price < 0 {
+					price = 0
 				}
 
-				rows = append(rows, []string{
+				entryRow := []string{
 					qtyStr,
-					`<ansi fg="petname">` + petInfo.Type + strings.Repeat(" ", 30-len(petInfo.Type)) + `</ansi>`,
-					strconv.Itoa(price)},
-				)
+					`<ansi fg="petname">` + petInfo.Type + `</ansi>`,
+					strconv.Itoa(price),
+				}
+
+				if hasTradeItems {
+					if stockPet.TradeItemId > 0 {
+						tradeItm := items.New(stockPet.TradeItemId)
+						entryRow = append(entryRow, fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, tradeItm.DisplayName()))
+					} else {
+						entryRow = append(entryRow, ``)
+					}
+				}
+
+				rows = append(rows, entryRow)
 			}
 
 			sort.Slice(rows, func(i, j int) bool {
@@ -291,11 +385,13 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				price := stockItm.Price
 				if price == 0 {
 					price = item.GetSpec().Value
+				} else if price < 0 {
+					price = 0
 				}
 
 				rows = append(rows, []string{
 					qtyStr,
-					fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, item.DisplayName()) + strings.Repeat(" ", 30-len(item.Name())),
+					fmt.Sprintf(`<ansi fg="itemname">%s</ansi>`, item.DisplayName()),
 					string(item.GetSpec().Type),
 					strconv.Itoa(price)},
 				)
@@ -338,11 +434,13 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				price := stockMerc.Price
 				if price == 0 {
 					price = 250 * mobInfo.Character.Level
+				} else if price < 0 {
+					price = 0
 				}
 
 				rows = append(rows, []string{
 					qtyStr,
-					`<ansi fg="mobname">` + mobInfo.Character.Name + `</ansi>` + strings.Repeat(" ", 30-len(mobInfo.Character.Name)),
+					`<ansi fg="mobname">` + mobInfo.Character.Name + `</ansi>`,
 					strconv.Itoa(mobInfo.Character.Level),
 					raceInfo.Name,
 					strconv.Itoa(price),
@@ -381,7 +479,7 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 				rows = append(rows, []string{
 					qtyStr,
-					buffInfo.Name + strings.Repeat(" ", 30-len(buffInfo.Name)),
+					buffInfo.Name,
 					strconv.Itoa(stockBuff.Price)},
 				)
 			}
@@ -418,11 +516,13 @@ func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				price := stockPet.Price
 				if price == 0 {
 					price = 10000
+				} else if price < 0 {
+					price = 0
 				}
 
 				rows = append(rows, []string{
 					qtyStr,
-					`<ansi fg="petname">` + petInfo.Type + strings.Repeat(" ", 30-len(petInfo.Type)) + `</ansi>`,
+					`<ansi fg="petname">` + petInfo.Type + `</ansi>`,
 					strconv.Itoa(price)},
 				)
 			}

--- a/internal/usercommands/sell.go
+++ b/internal/usercommands/sell.go
@@ -49,9 +49,7 @@ func Sell(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 		sellValue := mob.GetSellPrice(item)
 
 		if sellValue <= 0 {
-
 			mob.Command(`say I'm not interested in that.`)
-
 			continue
 		}
 


### PR DESCRIPTION
# Changes
* Shops can now require items in addition to gold for trade in purchasing.
  * Can require zero gold and only an item.
  * When gold is zero (default if unspecified), item prices are calculated dynamically. Therefore, a `-1` value must be specified in order to require ZERO gold.
* Shop lists with color "cells" were not padding/rendering correctly. This fixes that template.

![image](https://github.com/user-attachments/assets/60c09f27-93d2-4669-af69-bd8264dc353d)
