### PR TITLE
Saving current round count every 10 seconds

### DIFF
--- a/internal/configs/config_types.go
+++ b/internal/configs/config_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 type ConfigInt int
+type ConfigUInt64 uint64
 type ConfigString string
 type ConfigFloat float64
 type ConfigBool bool
@@ -17,6 +18,9 @@ type ConfigValue interface {
 }
 
 // String
+func (c ConfigUInt64) String() string {
+	return strconv.FormatUint(uint64(c), 10)
+}
 
 func (c ConfigInt) String() string {
 	return strconv.Itoa(int(c))
@@ -39,6 +43,15 @@ func (c ConfigSliceString) String() string {
 }
 
 // Set
+
+func (c *ConfigUInt64) Set(value string) error {
+	v, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return err
+	}
+	*c = ConfigUInt64(v)
+	return nil
+}
 
 func (c *ConfigInt) Set(value string) error {
 	v, err := strconv.Atoi(value)

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -100,6 +100,8 @@ type Config struct {
 
 	SeedInt int64 `yaml:"-"`
 
+	RoundCount ConfigUInt64 `yaml:"RoundCount,omitempty"` // Last saved round count
+
 	// Protected values
 	turnsPerRound   int     // calculated and cached when data is validated.
 	turnsPerSave    int     // calculated and cached when data is validated.

--- a/main.go
+++ b/main.go
@@ -130,7 +130,13 @@ func main() {
 	// Load all the data files up front.
 	loadAllDataFiles(false)
 
-	gametime.SetToDay(-3)
+	rc := uint64(c.RoundCount)
+	if rc > 0 {
+		util.SetRoundCount(uint64(c.RoundCount))
+	} else {
+		gametime.SetToDay(-3)
+	}
+
 	gametime.GetZodiac(1) // The first time this is called it randomizes all zodiacs
 
 	scripting.Setup(int(c.ScriptLoadTimeoutMs), int(c.ScriptRoomTimeoutMs))

--- a/world.go
+++ b/world.go
@@ -665,7 +665,7 @@ loop:
 			util.LockMud()
 			w.UpdateStats()
 			util.UnlockMud()
-
+			configs.SetVal(`RoundCount`, strconv.FormatUint(util.GetRoundCount(), 10))
 			statsTimer.Reset(time.Duration(10) * time.Second)
 
 		case <-roomUpdateTimer.C:


### PR DESCRIPTION
# Changes
* RoundCount is saved to `config-overrides.yaml` every 10 seconds
* When GoMud starts up, if a value is found, it uses it, otherwise falls back to default startup conditions.
