### PR TITLE
Test results fixes

### DIFF
--- a/_datafiles/buffs/0-meditating.js
+++ b/_datafiles/buffs/0-meditating.js
@@ -12,6 +12,6 @@ function onStart(actor, triggersLeft) {
 
 // Invoked every time the buff is triggered (see roundinterval)
 function onTrigger(actor, triggersLeft) {
-    SendUserMessage(actor.UserId(),     'You continue your meditation. <ansi bg="blue"> *' + triggersLeft + ' rounds left* </ansi>.' )
+    SendUserMessage(actor.UserId(),     'You continue your meditation. <ansi bg="blue"> *' + triggersLeft + ' rounds left* </ansi>' )
     SendRoomMessage(actor.GetRoomId(),   actor.GetCharacterName(true)+' continues meditating.', actor.UserId() )
 }

--- a/_datafiles/buffs/24-death_recovery.js
+++ b/_datafiles/buffs/24-death_recovery.js
@@ -1,0 +1,21 @@
+
+
+// Invoked every time the buff is triggered (see roundinterval)
+function onTrigger(actor, triggersLeft) {
+
+    healAmt = actor.AddHealth(UtilDiceRoll(1, 10))
+    manaAmt = actor.AddMana(UtilDiceRoll(1, 10))
+
+    if ( healAmt > 0 && manaAmt > 0 ) {
+        SendUserMessage(actor.UserId(),     'The shadow realm heals you for <ansi fg="healing">'+String(healAmt)+' damage</ansi> and restores <ansi fg="mana-100">'+String(manaAmt)+' mana</ansi>!')
+    } else if ( healAmt > 0 ) {
+        SendUserMessage(actor.UserId(),     'The shadow realm heals you for <ansi fg="healing">'+String(healAmt)+' damage</ansi>!')
+    } else if ( manaAmt > 0 ) {
+        SendUserMessage(actor.UserId(),     'The shadow realm restores <ansi fg="mana-100">'+String(manaAmt)+' mana</ansi>!')
+    }
+
+    if ( healAmt > 0 || manaAmt > 0 ) {
+        SendRoomMessage(actor.GetRoomId(),  actor.GetCharacterName(true)+' is recovering from a recent death.', actor.UserId())
+    }
+}
+

--- a/_datafiles/buffs/24-death_recovery.yaml
+++ b/_datafiles/buffs/24-death_recovery.yaml
@@ -1,0 +1,5 @@
+buffid: 24
+name: Death Recovery
+description: You are recovering from dying
+triggerrate: 1 rounds
+triggercount: 15

--- a/_datafiles/buffs/24-empty.yaml
+++ b/_datafiles/buffs/24-empty.yaml
@@ -1,8 +1,0 @@
-buffid: 24
-name: empty
-description: Placeholder
-triggerrate: 1 round
-triggercount: 20
-flags:
-  - cancel-on-combat
-  - cancel-on-action

--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -96,9 +96,9 @@ PVP: limited
 #   Minimum level one must be to be targetted or to target other players in PVP
 PVPMinimumLevel: 15
 # - XPScale -
-#   Scales XP Charts for character leveling. Lower means less required, higher
-#   means more required. 1 is the default (no change).
-XPScale: 1
+#   Scales how much XP is gained when characters gain XP. Number is a percentage
+#   Example: 100 = 100%
+XPScale: 100
 # - TurnMs -
 #   How many milliseconds per turn. While lower is generally better, this can
 #   greatly increase overhead on the server - a command per mob or user is

--- a/_datafiles/keywords.yaml
+++ b/_datafiles/keywords.yaml
@@ -220,6 +220,7 @@ command-aliases:
   leaderboard:      ['leaderboards', 'highscore', 'topscore']
   history:          ['log']
   time:             ['date']
+  noop:             ['wake']
   'party chat':     ['pchat', 'psay']
   'bank deposit':   ['deposit']
   'bank withdraw':  ['withdraw']

--- a/_datafiles/mobs/frostfang/11-brynja_snowdeal.yaml
+++ b/_datafiles/mobs/frostfang/11-brynja_snowdeal.yaml
@@ -21,12 +21,14 @@ character:
   shop:
     - itemid: 30001
       quantitymax: 3
+      restockrate: 1 hour
     - itemid: 20005
       quantitymax: 1
     - itemid: 6
       quantitymax: 3
     - itemid: 8
       quantitymax: 1
+      restockrate: 1 hour
     - itemid: 30015
       quantitymax: 2
   equipment:

--- a/_datafiles/mobs/frostfang/scripts/26-frostfang_citizen-locketsadness.js
+++ b/_datafiles/mobs/frostfang/scripts/26-frostfang_citizen-locketsadness.js
@@ -60,11 +60,15 @@ function onAsk(mob, room, eventDetails) {
 
 function onGive(mob, room, eventDetails) {
 
+    if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+        return false;
+    }
+    
+    
     showLocketCounter = mob.GetTempData('showLocketCounter');
     if ( showLocketCounter === null ) {
         showLocketCounter = {};
     }
-
 
     if (eventDetails.item) {
 

--- a/_datafiles/mobs/frostfang/scripts/38-player_guide.js
+++ b/_datafiles/mobs/frostfang/scripts/38-player_guide.js
@@ -140,7 +140,9 @@ function onAsk(mob, room, eventDetails) {
         return false;
     }
 
-    user = GetUser(eventDetails.sourceId);
+    if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+        return false;
+    }
 
     match = UtilFindMatchIn(eventDetails.askText, homeNouns);
     if ( match.found ) {

--- a/_datafiles/mobs/frostfang/scripts/39-elara.js
+++ b/_datafiles/mobs/frostfang/scripts/39-elara.js
@@ -34,6 +34,10 @@ function onGive(mob, room, eventDetails) {
         return false;
     }
 
+    if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+        return false;
+    }
+    
     if ( eventDetails.gold > 0 ) {
         mob.Command("say I'll use this money to buy more books!")
         return true;

--- a/_datafiles/mobs/frostfang/scripts/8-king.js
+++ b/_datafiles/mobs/frostfang/scripts/8-king.js
@@ -37,6 +37,10 @@ function onAsk(mob, room, eventDetails) {
 
 function onGive(mob, room, eventDetails) {
 
+    if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+        return false;
+    }    
+
     if (eventDetails.item) {
 
         if (eventDetails.item.ItemId == 20018) {
@@ -62,6 +66,10 @@ function onGive(mob, room, eventDetails) {
 
 function onShow(mob, room, eventDetails) {
 
+    if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+        return false;
+    }
+    
     if (eventDetails.item.ItemId == 20018) {
         
         mob.Command("say Thank you for taking care of that problem. The kingdom is indebted to you.")

--- a/_datafiles/mobs/frostfang_slums/scripts/40-rodric.js
+++ b/_datafiles/mobs/frostfang_slums/scripts/40-rodric.js
@@ -4,21 +4,25 @@ const thievesNouns = ["thief", "thieves", "guild", "hideout", "entrance", "dogs"
 
 function onAsk(mob, room, eventDetails) {
 
-    user = GetUser(eventDetails.sourceId);
 
-        // Waiting for a player to ask about the rats
-        if ( !user.HasQuest("7-start") ) {
-            startMatch = UtilFindMatchIn(eventDetails.askText, startNouns);
-            if ( startMatch.found ) {           
-                    mob.Command("say I'm worried about the rats in the slums. They're everywhere!");
-                    mob.Command("say I'm running out of traps and don't seem to be making a dent in the rat numbers.");
-                    mob.Command("say If you can kill 25 of them, come back and see me. I'll pay you for your trouble.");
-    
-                    user.GiveQuest("7-start");
-                    return true;
-            }
-            return false;
+    if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+        return false;
+    }
+
+
+    // Waiting for a player to ask about the rats
+    if ( !user.HasQuest("7-start") ) {
+        startMatch = UtilFindMatchIn(eventDetails.askText, startNouns);
+        if ( startMatch.found ) {           
+                mob.Command("say I'm worried about the rats in the slums. They're everywhere!");
+                mob.Command("say I'm running out of traps and don't seem to be making a dent in the rat numbers.");
+                mob.Command("say If you can kill 25 of them, come back and see me. I'll pay you for your trouble.");
+
+                user.GiveQuest("7-start");
+                return true;
         }
+        return false;
+    }
 
     // Waiting for players to show him 25 rodent kills
     if ( user.HasQuest("7-start") && !user.HasQuest("7-gettrap") ) {
@@ -92,8 +96,9 @@ function onGive(mob, room, eventDetails) {
             return true;
         }
 
-
-        user = GetUser(eventDetails.sourceId);
+        if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+            return false;
+        }    
 
         mob.Command("say Thank you so much! I can finally get back to catching some rats, and maybe earn a little coin.");
         mob.Command("say The thieves guild used to employ me to eliminate rats around their hideout, but for some reason they don't seem to need my help anymore, and didn't pay me for my last job I did for them.");

--- a/_datafiles/mobs/tutorial/scripts/58-training_dummy.js
+++ b/_datafiles/mobs/tutorial/scripts/58-training_dummy.js
@@ -4,7 +4,6 @@ function onDie(mob, room, eventDetails) {
 
     room.SendText( mob.GetCharacterName(true) + " crumbles to dust." );
 
-
     teacherMob = getTeacher(room);
 
     teacherMob.Command('say You did it! Head <ansi fg="exit">west</ansi> to complete your training.');

--- a/_datafiles/mobs/whispering_wastes/scripts/27-hermit-winterfire.js
+++ b/_datafiles/mobs/whispering_wastes/scripts/27-hermit-winterfire.js
@@ -37,6 +37,10 @@ function onGive(mob, room, eventDetails) {
         return false;
     }
 
+    if ( (user = GetUser(eventDetails.sourceId)) == null ) {
+        return false;
+    }
+    
     if ( eventDetails.gold > 0 ) {
         mob.Command("say Moneys no good here, but every now and then I can pay for a little help.")
         return true;

--- a/_datafiles/mutators/death_recovery.yaml
+++ b/_datafiles/mutators/death_recovery.yaml
@@ -13,6 +13,6 @@ mutatorid: death-recovery
 #decayintoid: another-alert-id
 #respawnrate: noon
 #decayrate: sunset
-playerbuffids: [4] # Heal
+playerbuffids: [24] # death-recovery
 #mobbuffids: []
 #nativebuffids: []

--- a/_datafiles/rooms/frostfang/265.yaml
+++ b/_datafiles/rooms/frostfang/265.yaml
@@ -15,6 +15,7 @@ spawninfo:
 - mobid: 26
   message: sophie steps out from another room.
   name: sophie
+  maxwander: 1
   scripttag: locketsadness
   questflags: [1-return]
   levelmod: 10

--- a/_datafiles/rooms/nowhere/-1.js
+++ b/_datafiles/rooms/nowhere/-1.js
@@ -1,0 +1,9 @@
+
+// If there is no book here, add the book item
+function onEnter(user, room) {
+    
+    user.SendText('  <ansi fg="red">To get started, type <ansi fg="command">look</ansi> or <ansi fg="command">start</ansi>.</ansi>');
+    user.SendText('');
+
+}
+

--- a/_datafiles/rooms/nowhere/-1.js
+++ b/_datafiles/rooms/nowhere/-1.js
@@ -6,4 +6,3 @@ function onEnter(user, room) {
     user.SendText('');
 
 }
-

--- a/_datafiles/rooms/shadow_realm/75.js
+++ b/_datafiles/rooms/shadow_realm/75.js
@@ -1,0 +1,14 @@
+
+
+function onIdle(room) {
+    
+    if ( room.AddTemporaryExit('shimmering portal', ':cyan', 0, '15 minutes') ) {
+        room.SendText('A portal to the world of the living appears!');
+    }
+    return false;
+}
+
+function onExit(user , room) {
+    // Remove the healing buff if they are leaving
+    user.RemoveBuff(24);
+}

--- a/_datafiles/templates/admincommands/ingame/roominfo.template
+++ b/_datafiles/templates/admincommands/ingame/roominfo.template
@@ -8,6 +8,8 @@
 <ansi fg="yellow-bold">Description:</ansi>    {{ splitstring $room.GetDescription 64 "                " }}
 <ansi fg="yellow-bold">Exits:</ansi>          {{ if eq (len $room.Exits) 0 }}None{{ else }}
 {{- range $command, $exitInfo := $room.Exits }}[<ansi fg="{{ if $exitInfo.Secret }}secret-{{ end }}exit">{{ $command }}</ansi> ⇒ <ansi fg="red">{{ $exitInfo.RoomId }}</ansi>] {{ end -}}{{ end }}
+<ansi fg="yellow-bold">Temp Exits:</ansi>     {{ if eq (len $room.ExitsTemp) 0 }}None{{ else }}
+{{- range $command, $exitInfo := $room.ExitsTemp }}[<ansi fg="exit">{{ $command }}</ansi> ⇒ <ansi fg="red">{{ $exitInfo.RoomId }}</ansi>] {{ end -}}{{ end }}
 <ansi fg="yellow-bold">Training:</ansi>       {{ if eq (len $room.SkillTraining) 0 }}None{{ else }}{{- range $index, $skill := $room.SkillTraining }}[{{ $skill }}] {{ end -}}{{ end }}
 <ansi fg="yellow-bold">Script:</ansi>         {{ if gt (len $room.GetScript) 0 }}<ansi fg="green">Yes</ansi> - <ansi fg="129">{{ $room.GetScriptPath }}</ansi>{{ else }}<ansi fg="red">No</ansi>{{ end }}
 <ansi fg="yellow-bold">Room Mutators:</ansi>  {{ range $i, $a := $room.Mutators }}<ansi fg="mutator">{{ $a.MutatorId }}</ansi> {{ if $a.Live }}<ansi fg="12">(active)</ansi>{{else}}<ansi fg="red">(inactive)</ansi>{{ end }}

--- a/internal/characters/alignment.go
+++ b/internal/characters/alignment.go
@@ -19,7 +19,7 @@ const (
 	AlignmentEvil      int8 = -60
 	AlignmentUnholy    int8 = -80
 	// Threshold by which mobs will auto aggro
-	AlignmentAggroThreshold int = 50 // Possible delta is 0 - 200
+	AlignmentAggroThreshold int = 100 // Possible delta is 0 - 200
 
 )
 

--- a/internal/characters/character.go
+++ b/internal/characters/character.go
@@ -425,6 +425,9 @@ func (c *Character) GrantXP(xp int) (actualXP int, xpScale int) {
 		return 0, 100
 	}
 
+	preScale := float64(configs.GetConfig().XPScale) / 100
+	xp = int(math.Round(preScale * float64(xp)))
+
 	xpScale = c.StatMod(string(statmods.XPScale)) + 100
 
 	if xpScale == 100 {
@@ -1236,7 +1239,7 @@ func (c *Character) XPTNL() int {
 // Amt TNL for a specific level
 func (c *Character) XPTL(lvl int) int {
 	fLvl := float64(lvl)
-	return int(float32(1000+(fLvl*(fLvl*.75)*1000)) * c.TNLScale * float32(configs.GetConfig().XPScale))
+	return int(float32(1000+(fLvl*(fLvl*.75)*1000)) * c.TNLScale)
 }
 
 // Returns the actual xp in regards to the current level/next level

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -303,7 +303,7 @@ func (c *Config) SetOverrides(overrides map[string]any) error {
 	structValue := reflect.ValueOf(c).Elem()
 	for name, value := range c.overrides {
 
-		slog.Info("SetOverrides()", "name", name, "value", value)
+		slog.Debug("SetOverrides()", "name", name, "value", value)
 
 		structFieldValue := structValue.FieldByName(name)
 

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -414,7 +414,7 @@ func (c *Config) Validate() {
 	}
 
 	if c.XPScale <= 0 {
-		c.XPScale = 1.0 // default
+		c.XPScale = 100.0 // default
 	}
 
 	if c.TurnMs < 10 {

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -6,7 +6,7 @@ import "github.com/volte6/gomud/internal/gamelock"
 // There is a magical hole in the east wall here!
 type TemporaryRoomExit struct {
 	RoomId       int    // Where does it lead to?
-	Title        string // Does this exist have a special title?
+	Title        string // Does this exit have a special title?
 	UserId       int    // Who created it?
 	SpawnedRound uint64 `yaml:"-"` // When the temp exit was created
 	Expires      string // When will it be auto-cleaned up?

--- a/internal/mobcommands/suicide.go
+++ b/internal/mobcommands/suicide.go
@@ -98,6 +98,12 @@ func Suicide(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		for uId, _ := range mob.Character.PlayerDamage {
 			if user := users.GetByUserId(uId); user != nil {
 
+				if user.Character.Aggro != nil {
+					if user.Character.Aggro.MobInstanceId == mob.InstanceId {
+						user.Character.Aggro = nil
+					}
+				}
+
 				scripting.TryMobScriptEvent(`onDie`, mob.InstanceId, uId, `user`, map[string]any{`attackerCount`: attackerCt})
 
 				p := parties.Get(user.UserId)

--- a/internal/rooms/roomdetails.go
+++ b/internal/rooms/roomdetails.go
@@ -103,8 +103,7 @@ func GetDetails(r *Room, user *users.UserRecord) RoomTemplateDetails {
 	}
 
 	if r.RoomId == -1 {
-		details.RoomAlerts = append(details.RoomAlerts, `<ansi fg="yellow-bold">Type <ansi fg="command">help races</ansi> to see a list of available races.</ansi>`+
-			"\n"+`      <ansi fg="yellow-bold">Type <ansi fg="command">start</ansi> to begin playing.</ansi>`)
+		details.RoomAlerts = append(details.RoomAlerts, `      <ansi fg="yellow-bold">Type <ansi fg="command">start</ansi> to begin playing.</ansi>`)
 	}
 
 	if r.IsBurning() {

--- a/internal/rooms/roomdetails.go
+++ b/internal/rooms/roomdetails.go
@@ -265,7 +265,7 @@ func GetDetails(r *Room, user *users.UserRecord) RoomTemplateDetails {
 		}
 	}
 
-	if user.Character.Pet.Exists() {
+	if user.Character.Pet.Exists() && r.RoomId == user.Character.RoomId {
 		details.VisiblePlayers = append(details.VisiblePlayers, fmt.Sprintf(`%s (your pet)`, user.Character.Pet.DisplayName()))
 	}
 

--- a/internal/rooms/rooms.go
+++ b/internal/rooms/rooms.go
@@ -2123,6 +2123,10 @@ func (r *Room) IsPvp() bool {
 // Returns an error with a reason why they cannot PVP, or nil
 func (r *Room) CanPvp(attUser *users.UserRecord, defUser *users.UserRecord) error {
 
+	if attUser.Character.RoomId == -1 || attUser.Character.RoomId == 75 {
+		return errors.New(`Fighting is not allowed here.`)
+	}
+
 	c := configs.GetConfig()
 
 	// Possible settings are `enabled`, `disabled`, `limited`

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -374,12 +374,26 @@ func (a ScriptActor) UpdateItem(itm ScriptItem) {
 	a.userRecord.Character.UpdateItem(itm.originalItem, *itm.itemRecord)
 }
 
-func (a ScriptActor) GiveItem(itm ScriptItem) {
-	if a.characterRecord.StoreItem(*itm.itemRecord) {
+func (a ScriptActor) GiveItem(itm any) {
+
+	var sItem ScriptItem
+
+	if itmScriptItem, ok := itm.(ScriptItem); ok {
+		sItem = itmScriptItem
+	} else if itmInt, ok := itm.(int64); ok {
+		sItem = *CreateItem(int(itmInt))
+	} else if itmInt, ok := itm.(int32); ok {
+		sItem = *CreateItem(int(itmInt))
+	} else if itmFloat, ok := itm.(float64); ok {
+		sItem = *CreateItem(int(itmFloat))
+	}
+
+	if a.characterRecord.StoreItem(*sItem.itemRecord) {
 		if a.userId > 0 {
-			TryItemScriptEvent(`onGive`, *itm.itemRecord, a.userId)
+			TryItemScriptEvent(`onGive`, *sItem.itemRecord, a.userId)
 		}
 	}
+
 }
 
 func (a ScriptActor) TakeItem(itm ScriptItem) {

--- a/internal/scripting/buff.go
+++ b/internal/scripting/buff.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	buffVMCache       = make(map[int]*VMWrapper)
-	scriptBuffTimeout = 10 * time.Millisecond
+	scriptBuffTimeout = 50 * time.Millisecond
 )
 
 func ClearBuffVMs() {

--- a/internal/scripting/item.go
+++ b/internal/scripting/item.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	itemVMCache       = make(map[string]*VMWrapper)
-	scriptItemTimeout = 10 * time.Millisecond
+	scriptItemTimeout = 50 * time.Millisecond
 )
 
 func ClearItemVMs() {

--- a/internal/scripting/mob.go
+++ b/internal/scripting/mob.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	mobVMCache       = make(map[string]*VMWrapper)
-	scriptMobTimeout = 10 * time.Millisecond
+	scriptMobTimeout = 50 * time.Millisecond
 )
 
 func ClearMobVMs() {

--- a/internal/scripting/room.go
+++ b/internal/scripting/room.go
@@ -14,7 +14,7 @@ import (
 var (
 	roomVMCache       = make(map[int]*VMWrapper)
 	scriptLoadTimeout = 1000 * time.Millisecond
-	scriptRoomTimeout = 10 * time.Millisecond
+	scriptRoomTimeout = 50 * time.Millisecond
 )
 
 func ClearRoomVMs() {

--- a/internal/scripting/spell.go
+++ b/internal/scripting/spell.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	spellVMCache       = make(map[string]*VMWrapper)
-	scriptSpellTimeout = 10 * time.Millisecond
+	scriptSpellTimeout = 50 * time.Millisecond
 )
 
 func ClearSpellVMs() {

--- a/internal/usercommands/attack.go
+++ b/internal/usercommands/attack.go
@@ -138,12 +138,12 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 			user.Character.SetAggro(0, attackMobInstanceId, characters.DefaultAttack)
 
 			user.SendText(
-				fmt.Sprintf(`You prepare to enter into mortal combat with <ansi fg="mobname">%s</ansi>`, m.Character.Name),
+				fmt.Sprintf(`You prepare to enter into mortal combat with <ansi fg="mobname">%s</ansi>.`, m.Character.Name),
 			)
 
 			if !isSneaking {
 				room.SendText(
-					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>`, user.Character.Name, m.Character.Name),
+					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>.`, user.Character.Name, m.Character.Name),
 					user.UserId,
 				)
 			}
@@ -194,7 +194,7 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 			user.Character.SetAggro(attackPlayerId, 0, characters.DefaultAttack)
 
 			user.SendText(
-				fmt.Sprintf(`You prepare to enter into mortal combat with <ansi fg="username">%s</ansi>`, p.Character.Name),
+				fmt.Sprintf(`You prepare to enter into mortal combat with <ansi fg="username">%s</ansi>.`, p.Character.Name),
 			)
 
 			if !isSneaking {
@@ -204,7 +204,7 @@ func Attack(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 				)
 
 				room.SendText(
-					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>`, user.Character.Name, p.Character.Name),
+					fmt.Sprintf(`<ansi fg="username">%s</ansi> prepares to fight <ansi fg="mobname">%s</ansi>.`, user.Character.Name, p.Character.Name),
 					user.UserId, attackPlayerId)
 			}
 

--- a/internal/usercommands/give.go
+++ b/internal/usercommands/give.go
@@ -22,7 +22,7 @@ func Give(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
 	if len(args) < 2 {
-		user.SendText("Give what? To whom?")
+		user.SendText(`Give what? To whom? (<ansi fg="command">give {object-name} {receiver-name}</ansi>)`)
 		return true, nil
 	}
 
@@ -56,7 +56,7 @@ func Give(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 		giveItem, found = user.Character.FindInBackpack(giveWhat)
 
 		if !found {
-			user.SendText(fmt.Sprintf("You don't have a %s to give.", giveWhat))
+			user.SendText(fmt.Sprintf(`You don't have a %s to give. (<ansi fg="command">give {object-name} {receiver-name}</ansi>)`, giveWhat))
 			return true, nil
 		}
 
@@ -232,7 +232,7 @@ func Give(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 		return true, nil
 	}
 
-	user.SendText("Who???")
+	user.SendText(`Who??? (<ansi fg="command">give {object-name} {receiver-name}</ansi>)`)
 
 	return true, nil
 }

--- a/internal/usercommands/go.go
+++ b/internal/usercommands/go.go
@@ -2,6 +2,7 @@ package usercommands
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/volte6/gomud/internal/buffs"
 	"github.com/volte6/gomud/internal/configs"
@@ -153,6 +154,7 @@ func Go(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 			user.SendText("Oops, couldn't move there!")
 		} else {
 
+			slog.Info("Calling onExit")
 			scripting.TryRoomScriptEvent(`onExit`, user.UserId, originRoomId)
 
 			c := configs.GetConfig()

--- a/internal/usercommands/noop.go
+++ b/internal/usercommands/noop.go
@@ -1,0 +1,11 @@
+package usercommands
+
+import (
+	"github.com/volte6/gomud/internal/rooms"
+	"github.com/volte6/gomud/internal/users"
+)
+
+// This is a no-op, does nothing
+func Noop(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+	return true, nil
+}

--- a/internal/usercommands/online.go
+++ b/internal/usercommands/online.go
@@ -17,10 +17,6 @@ func Online(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 	rows := [][]string{}
 
-	rowsAdmin := [][]string{}
-	rowsMod := [][]string{}
-	rowsUser := [][]string{}
-
 	userCt := 0
 	for _, uid := range users.GetOnlineUserIds() {
 
@@ -57,20 +53,9 @@ func Online(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 			allFormatting = append(allFormatting, formatting)
 
-			if u.Permission == users.PermissionAdmin {
-				rowsAdmin = append(rowsAdmin, row)
-			} else if u.Permission == users.PermissionMod {
-				rowsMod = append(rowsMod, row)
-			} else {
-				rowsUser = append(rowsUser, row)
-			}
-
+			rows = append(rows, row)
 		}
 	}
-
-	rows = append(rows, rowsAdmin...)
-	rows = append(rows, rowsMod...)
-	rows = append(rows, rowsUser...)
 
 	tableTitle := fmt.Sprintf(`%d users online`, userCt)
 	if userCt == 1 {

--- a/internal/usercommands/skill.portal.go
+++ b/internal/usercommands/skill.portal.go
@@ -23,6 +23,10 @@ Level 4 - Create a physical portal that you can share with players, or return th
 */
 func Portal(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
+	if user.Character.RoomId == 75 {
+		return false, errors.New(`portal command ignored in death recovery`)
+	}
+
 	// This is a hack because using "portal" to enter an existing portal is very common
 	if rest == `` {
 		if handled, err := Go(`portal`, user, room); handled {

--- a/internal/usercommands/suicide.go
+++ b/internal/usercommands/suicide.go
@@ -180,6 +180,7 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 	user.Character.CancelBuffsWithFlag(buffs.All)
 
 	user.Character.Health = -10
+	user.Character.Mana = 0
 
 	clear(user.Character.PlayerDamage)
 

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -89,6 +89,7 @@ var (
 		`modify`:      {Modify, true, true}, // Admin only
 		`motd`:        {Motd, true, false},
 		`mute`:        {Mute, true, true},
+		`noop`:        {Noop, true, false},
 		`offer`:       {Offer, false, false},
 		`online`:      {Online, true, false},
 		`party`:       {Party, true, false},

--- a/world.go
+++ b/world.go
@@ -1321,7 +1321,7 @@ func (w *World) TurnTick() {
 			continue
 		}
 
-		if rooms.EffectType(action.Action) == rooms.Wildfire {
+		if rooms.EffectType(action.Action) == rooms.Wildfire && room.GetBiome().Burns() {
 
 			if room.AddEffect(rooms.Wildfire) {
 				room.SendText(colorpatterns.ApplyColorPattern(`A wildfire burns through the area!`, `flame`, colorpatterns.Stretch))

--- a/world.roundtick.go
+++ b/world.roundtick.go
@@ -10,12 +10,10 @@ import (
 	"github.com/volte6/gomud/internal/auctions"
 	"github.com/volte6/gomud/internal/buffs"
 	"github.com/volte6/gomud/internal/characters"
-	"github.com/volte6/gomud/internal/colorpatterns"
 	"github.com/volte6/gomud/internal/combat"
 	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/connections"
 	"github.com/volte6/gomud/internal/events"
-	"github.com/volte6/gomud/internal/exit"
 	"github.com/volte6/gomud/internal/gametime"
 	"github.com/volte6/gomud/internal/items"
 	"github.com/volte6/gomud/internal/mobs"
@@ -130,11 +128,6 @@ func (w *World) roundTick() {
 	// Idle mobs
 	//
 	w.handleIdleMobs()
-
-	//
-	// Shadow/death realm
-	//
-	w.handleShadowRealm(roundNumber)
 
 	util.TrackTime(`World::RoundTick()`, time.Since(tStart).Seconds())
 }
@@ -1658,38 +1651,6 @@ func (w *World) handleAutoHealing(roundNumber uint64) {
 			)
 		}
 
-	}
-
-}
-
-// Special shadow realm stuff
-func (w *World) handleShadowRealm(roundNumber uint64) {
-
-	if roundNumber%uint64(configs.GetConfig().MinutesToRounds(1)) == 0 {
-
-		// room 75 is the Shadow Realm
-		deadRoom := rooms.LoadRoom(75)
-
-		players := deadRoom.GetPlayers()
-		if len(players) > 0 {
-
-			type TemporaryRoomExit struct {
-				RoomId  int       // Where does it lead to?
-				Title   string    // Does this exist have a special title?
-				UserId  int       // Who created it?
-				Expires time.Time // When will it be auto-cleaned up?
-			}
-
-			tmpExit := exit.TemporaryRoomExit{
-				RoomId:  rooms.StartRoomIdAlias,
-				Title:   colorpatterns.ApplyColorPattern(`shimmering portal`, `cyan`),
-				UserId:  0,
-				Expires: `3 rounds`,
-			}
-			// Spawn a portal in the room that leads to the portal location
-			deadRoom.AddTemporaryExit("shimmering portal", tmpExit)
-			deadRoom.SendText(`<ansi fg="magenta-bold">A shimmering portal appears in the room.</ansi>`)
-		}
 	}
 
 }


### PR DESCRIPTION
# Motivation
This fixes several issues discovered during a playtest session with many users connecting and creating new accounts at once:

# Changes
* `wake` command being used to attempt to wake. In reality any input wakes. Created a `noop` for situations where I want to alias commands that actually do nothing but still register as a command. Aliased `wake` to `noop`
* Updated the scripting `actor.GiveItem()` to accept an item Id to grant a new version of an item
* Updated lots of scripts that referenced a user object that wasn't yet created
* Fixed an issue with `online` command using wrong alignment colorizing for users.
* Made mobs less aggressive against alignment differences (now a 100 pt diff vs. 50 pt diff required)
* Fixed sophie script bugs, decreased her wander distance to 1
* Removing aggro from players when their target dies.
* xpScale was implemented incorrectly. Now doesn't scale xp TNL in addition to payout (net zero result), but only the xp gained. Also changed config to use a float value and 100 = 100% instead of 1 = 100%.
* Your pet no longer appears in every room you look into from another area.
* Addresses a huge bug where userId's were being assigned/shared by users who signup during the same period. 
  * Previously would use count of user files to determine next userId, but new users don't write user files until they finish the tutorial and a save event occurs.
* Increased script timeout to 50ms for extreme situations.
* Adding a hint when `give` command fails for proper syntax
* Shadow realm now handled by a script, recovery now has its own buff, and buff is removed when leaving shadow realm.
* PVP Combat disallowed in shadow realm.
* Adding a message when first joining with a new account to `look` or `start`, just for additional encouragement.