### PR TITLE
Conversations configuration and bug fix

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -261,6 +261,9 @@ MaxMobBoredom: 250
 # - MobUnloadThreshold -
 #   Do not unload any bots if the in-memory count is under this threshold.
 MobUnloadThreshold: 100
+# - MobConverseChance -
+#   Chance in 100 that the mob will attempt to converse when idle.
+MobConverseChance: 3
 # - ScriptLoadTimeoutMs -
 #   When a script is first loaded, compiled, and run, it is given this long to
 #   complete. If it takes longer, it is killed. This includes the onLoad() function

--- a/_datafiles/html/admin/mobs/mob.data.html
+++ b/_datafiles/html/admin/mobs/mob.data.html
@@ -22,7 +22,7 @@
             <select class="form-control form-control-sm" name="activitylevel" id="activitylevel" aria-describedby="activitylevel-help"  rows="10">
             {{$mobActivityLevel := .mobInfo.ActivityLevel}}
             {{range $index, $level := .activityLevels}}
-                <option value="{{ $level }}" {{if eq $level $mobActivityLevel}}SELECTED{{end}}>{{ mul $level 10 }}%</option>
+                <option value="{{ $level }}" {{if eq $level $mobActivityLevel}}SELECTED{{end}}>{{ mul $level }}%</option>
             {{end}}
             </select>
             <small id="activitylevel-help" class="form-text text-muted">How active this mob is.</small>

--- a/_datafiles/mobs/catacombs/14-lich.yaml
+++ b/_datafiles/mobs/catacombs/14-lich.yaml
@@ -7,7 +7,7 @@ groups:
   - catacomb-denizen
 idlecommands:
   - 'emote creaks and sways'
-activitylevel: 1
+activitylevel: 10
 character:
   name: lich
   description: 'The lich, once a king of unparalleled might, now stands as a gaunt figure shrouded in tattered royal vestments that cling to its skeletal frame. Its hollow eye sockets burn with an eldritch fire, a testament to the dark sorcery that anchors its undying spirit to the mortal plane, and in its withered hand, it clutches an ancient and malevolent scepter, casting an aura of fear and decay over the realm it refuses to relinquish.'

--- a/_datafiles/mobs/catacombs/15-skeleton.yaml
+++ b/_datafiles/mobs/catacombs/15-skeleton.yaml
@@ -7,7 +7,7 @@ groups:
   - catacomb-denizen
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: skeleton
   description: 'The skeleton before you is a grim tapestry of warfare past, its bones bleached by time and clattering in the still air of the catacombs. Clad in the tattered remnants of its battle regalia, it stands guard, a silent sentinel animated by some unfathomable necromancy. Each movement it makes is a haunting echo of its martial prowess, the rusted sword it grips is unwavering and ready, a testament to its undying vigilance and the undying will that drives it.'

--- a/_datafiles/mobs/catacombs/16-dark_acolyte_trainer.yaml
+++ b/_datafiles/mobs/catacombs/16-dark_acolyte_trainer.yaml
@@ -8,7 +8,7 @@ idlecommands:
   - 'say I can help you <ansi fg="command">train</ansi> new skills!'
   - emote clears his throat
   - 'say I have picked up a few useful skills for navigating these catacombs.'
-activitylevel: 1
+activitylevel: 10
 character:
   name: dark acolyte trainer
   description: 'He appears to mean no harm, and may even have a few things to teach you.'

--- a/_datafiles/mobs/catacombs/17-dark_acolyte.yaml
+++ b/_datafiles/mobs/catacombs/17-dark_acolyte.yaml
@@ -5,7 +5,7 @@ hostile: true
 maxwander: -1
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: dark acolyte
   description: 'Before you stands a solitary dark acolyte, an ominous figure enshrouded in a tattered ebony robe that seems to absorb the weak light around it. His face is obscured by the shadow of his hood, with only the faint glimmer of his malevolent gaze piercing the darkness. An aura of desolation clings to him, and the air grows colder in his presence. In one skeletal hand, he clutches a staff topped with a skull that emanates a soft, baleful light, symbolizing his mastery over the necrotic energies that pervade the catacombs. He remains motionless, a silent sentinel awaiting the command of his unseen master, yet the oppressive force of his malevolent intent is as tangible as the ancient stone beneath your feet.'

--- a/_datafiles/mobs/catacombs/18-dark_acolyte.yaml
+++ b/_datafiles/mobs/catacombs/18-dark_acolyte.yaml
@@ -7,7 +7,7 @@ groups:
   - catacomb-denizen
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: dark acolyte
   description: 'Before you stands a solitary dark acolyte, an ominous figure enshrouded in a tattered ebony robe that seems to absorb the weak light around it. His face is obscured by the shadow of his hood, with only the faint glimmer of his malevolent gaze piercing the darkness. An aura of desolation clings to him, and the air grows colder in his presence. In one skeletal hand, he clutches a staff topped with a skull that emanates a soft, baleful light, symbolizing his mastery over the necrotic energies that pervade the catacombs. He remains motionless, a silent sentinel awaiting the command of his unseen master, yet the oppressive force of his malevolent intent is as tangible as the ancient stone beneath your feet.'

--- a/_datafiles/mobs/catacombs/19-large_spider.yaml
+++ b/_datafiles/mobs/catacombs/19-large_spider.yaml
@@ -7,7 +7,7 @@ groups:
   - spider
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: large spider
   description: 'Its massive body is covered in a chitinous armor, glossy and black as obsidian, with hints of a deep, iridescent purple when caught by the flicker of torchlight. The arachnid''s legs span wide, each segment a testament to its predatory prowess, ending in sharp points that click ominously against the stone floor. Its eyes, a cluster of glistening orbs, reflect a malevolent intelligence, surveying its domain for any disturbance. The creature''s fangs glisten with venom, capable of paralyzing its unsuspecting prey with a single bite. Silent as a whisper, it waits in the gloom, its web a masterpiece of deadly beauty, strung between the bones of the less fortunate who now serve as a warning to those who traverse the spider''s lair.'

--- a/_datafiles/mobs/catacombs/20-baby_spider.yaml
+++ b/_datafiles/mobs/catacombs/20-baby_spider.yaml
@@ -7,7 +7,7 @@ groups:
   - spider
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: baby spider
   description: 'Its massive body is covered in a chitinous armor, glossy and black as obsidian, with hints of a deep, iridescent purple when caught by the flicker of torchlight. The arachnid''s legs span wide, each segment a testament to its predatory prowess, ending in sharp points that click ominously against the stone floor. Its eyes, a cluster of glistening orbs, reflect a malevolent intelligence, surveying its domain for any disturbance. The creature''s fangs glisten with venom, capable of paralyzing its unsuspecting prey with a single bite. Silent as a whisper, it waits in the gloom, its web a masterpiece of deadly beauty, strung between the bones of the less fortunate who now serve as a warning to those who traverse the spider''s lair.'

--- a/_datafiles/mobs/catacombs/21-bonecrafter.yaml
+++ b/_datafiles/mobs/catacombs/21-bonecrafter.yaml
@@ -16,7 +16,7 @@ idlecommands:
   - ''
   - 'wander'
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: bonecrafter
   description: 'The necromancer known as the Bonecrafter practices his grim craft. Cloaked in a robe that seems woven from the very darkness around him, his presence is an unnerving calm in the chaos of decay. His face, pale and gaunt, is marked with lines of concentration and arcane knowledge, with eyes that gleam with a morbid fascination for the dead. His fingers, long and delicate, dance with precision as he conducts the macabre ritual to awaken the bones that lie silent in the tombs. The necromancer''s lips whisper incantations that have not been heard by the living for centuries, and with each word, the skeletons jerk into a semblance of life, ready to serve those willing to pay his price.'

--- a/_datafiles/mobs/dark_forest/32-sentient_fungus.yaml
+++ b/_datafiles/mobs/dark_forest/32-sentient_fungus.yaml
@@ -8,7 +8,7 @@ groups:
 idlecommands:
   - 'emote bulges a little bit'
   - 'emote releases some spores'
-activitylevel: 1
+activitylevel: 10
 character:
   name: sentient fungus
   description: 'Its cap, several feet in diameter, emits a soft, eerie glow. Veins of bioluminescence run across its surface, pulsating in a rhythmic pattern. As you approach, a faint, melodic hum emanates from the fungus—a musical language that resonates with the forest.'

--- a/_datafiles/mobs/dark_forest/33-forest_imp.yaml
+++ b/_datafiles/mobs/dark_forest/33-forest_imp.yaml
@@ -10,7 +10,7 @@ idlecommands:
   - 'emote hums a soft melody'
 combatcommands:
   - 'callforhelp tilts his head back and lets out a shrill cry!'
-activitylevel: 1
+activitylevel: 10
 character:
   name: forest imp
   description: 'Standing at just knee height, this creature possesses a lithe and agile form, covered in mossy-green skin that seamlessly blends with the surrounding foliage. Its large, almond-shaped eyes sparkle with an impish curiosity, and a crown of leaves and twigs adorns its head. The Forest Imp''s pointed ears twitch as it gazes back at you, revealing a sly intelligence that belies its whimsical appearance. Its fingers end in tiny, nimble claws, perfect for climbing and playing pranks.'

--- a/_datafiles/mobs/dark_forest/34-ent.yaml
+++ b/_datafiles/mobs/dark_forest/34-ent.yaml
@@ -9,7 +9,7 @@ idlecommands:
   - 'emote creeks and sways'
 combatcommands:
   - 'callforhelp calls upon the forest denizens for help!'
-activitylevel: 1
+activitylevel: 10
 character:
   name: ent
   description: 'Thick, mossy growths cling to its rough surface, and lush vines and ivy drape from its branches, creating an awe-inspiring spectacle. The Ent''s eyes, deep and wise, are set within the rough texture of its bark, shining with a profound intelligence that spans centuries.'

--- a/_datafiles/mobs/dark_forest/35-spider_hatchling.yaml
+++ b/_datafiles/mobs/dark_forest/35-spider_hatchling.yaml
@@ -7,7 +7,7 @@ groups:
   - spider
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: spider hatchling
   description: 'Its massive body is covered in a chitinous armor, glossy and black as obsidian, with hints of a deep, iridescent purple. The arachnid''s legs span wide, each segment a testament to its predatory prowess. Its eyes, a cluster of glistening orbs, reflect a malevolent intelligence, surveying its domain for any disturbance. The creature''s fangs glisten with venom, capable of paralyzing its unsuspecting prey with a single bite. Silent as a whisper, it waits in the gloom, its web a masterpiece of deadly beauty, strung between the bones of the less fortunate who now serve as a warning to those who traverse the spider''s lair.'

--- a/_datafiles/mobs/dark_forest/36-spider_warrior.yaml
+++ b/_datafiles/mobs/dark_forest/36-spider_warrior.yaml
@@ -7,7 +7,7 @@ groups:
   - spider
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: spider warrior
   description: 'Its massive body is covered in a chitinous armor, glossy and black as obsidian, with hints of a deep, iridescent purple. The arachnid''s legs span wide, each segment a testament to its predatory prowess. Its eyes, a cluster of glistening orbs, reflect a malevolent intelligence, surveying its domain for any disturbance. The creature''s fangs glisten with venom, capable of paralyzing its unsuspecting prey with a single bite. Silent as a whisper, it waits in the gloom, its web a masterpiece of deadly beauty, strung between the bones of the less fortunate who now serve as a warning to those who traverse the spider''s lair.'

--- a/_datafiles/mobs/dark_forest/37-spider_queen.yaml
+++ b/_datafiles/mobs/dark_forest/37-spider_queen.yaml
@@ -7,7 +7,7 @@ groups:
   - spider
 combatcommands:
   - 'callforhelp chitters and clicks urgently.'
-activitylevel: 1
+activitylevel: 10
 character:
   name: spider queen
   description: 'The Spider Queen is an abhorrent sight to behold. Her bloated abdomen, swollen with the promise of countless offspring, hangs low, dragging across the silken webs that shroud her lair. Her legs, eight in total, are covered in thick, chitinous armor that gleams with a sickly iridescence, each limb ending in razor-sharp, venomous claws.'

--- a/_datafiles/mobs/dark_forest/43-faerie_folk.yaml
+++ b/_datafiles/mobs/dark_forest/43-faerie_folk.yaml
@@ -12,7 +12,7 @@ idlecommands:
   - 'emote wipes their brow.'
 combatcommands:
   - 'emote draws a foreign symbol in the air, and suddenly vanishes in a shower of sparks;suicide vanish'
-activitylevel: 3
+activitylevel: 30
 character:
   name: faerie folk
   description: 'The faerie is a delicate, ethereal being, no taller than a human hand, with iridescent wings that shimmer like dew-kissed spider silk in the dappled forest light. Their luminous skin glows softly, casting a gentle light on their surroundings as they flit gracefully among the trees and flowers. With eyes that sparkle like tiny gemstones, they move with a quick, darting motion, tending to the forest''s flora and fauna with a tender touch and a whisper of ancient magic. Faeries are intensely shy and easily startled; at the slightest hint of danger or a sudden noise, they vanish in a blink, leaving behind only a faint trail of sparkling dust and the lingering scent of wildflowers. Despite their elusiveness, the forest thrives under their care, each leaf and creature subtly blessed by their gentle, nurturing presence.'

--- a/_datafiles/mobs/dark_forest/56-timber_wolf.yaml
+++ b/_datafiles/mobs/dark_forest/56-timber_wolf.yaml
@@ -3,7 +3,7 @@ zone: Dark Forest
 itemdropchance: 1
 hostile: false
 maxwander: 5
-activitylevel: 1
+activitylevel: 10
 character:
   name: timber wolf
   description: 'The Timber Wolf is a hulking predator that prowls the shadowed depths of the Dark Forest, its mottled fur a blend of earthy browns and deep grays, perfectly suited to the dense, mist-laden woods it calls home. Unlike its northern cousins, the Timber Wolf is built for strength rather than speed, with a muscular frame and thick, knotted limbs that allow it to tear through underbrush and climb over fallen trees in pursuit of its prey. Its amber eyes gleam with a fierce intelligence, always scanning for movement among the forest shadows. The Timber Wolf is a pack animal, but its packs are smaller and more territorial, often staking claim to entire swathes of the forest. Its low, rumbling growl can be heard long before it strikes, a warning to those who dare venture into its realm.'

--- a/_datafiles/mobs/endless_trashheap/13-loot_goblin.yaml
+++ b/_datafiles/mobs/endless_trashheap/13-loot_goblin.yaml
@@ -27,7 +27,7 @@ idlecommands:
   - 'alchemy random'
 combatcommands:
   - 'portal home;go portal;drop all;wander'
-activitylevel: 9
+activitylevel: 90
 character:
   name: loot goblin
   description: 'The Loot Goblin is a creature of legend among treasure hunters and adventurers, a skittish and elusive being whose obsession with objects both precious and mundane is unparalleled. Clad in mismatched patches of clothing and armor, this diminutive figure scurries through dungeons and across battlefields, its bulging sack jingling with a cacophony of pilfered trinkets and rarities. Its eyes, wide and gleaming with avarice, never stop darting around, always seeking the next addition to its hoard.'

--- a/_datafiles/mobs/frost_lake/44-fisherman.yaml
+++ b/_datafiles/mobs/frost_lake/44-fisherman.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 20
 groups: 
   - frostfang-npc
-activitylevel: 2
+activitylevel: 20
 idlecommands:
   - 'say I really just want to focus on fishing these days, but I''ll let you train here if you want.'
   - 'emote examines his tacklebox.'

--- a/_datafiles/mobs/frost_lake/60-crocodile.yaml
+++ b/_datafiles/mobs/frost_lake/60-crocodile.yaml
@@ -3,7 +3,7 @@ zone: Frost Lake
 itemdropchance: 2
 hostile: true
 maxwander: 1
-activitylevel: 1
+activitylevel: 10
 idlecommands:
   - 'wander'
 character:

--- a/_datafiles/mobs/frostfang/1-rat.yaml
+++ b/_datafiles/mobs/frostfang/1-rat.yaml
@@ -10,7 +10,7 @@ idlecommands:
   - 'emote wiggles its nose'
   - 'wander'
   - ''
-activitylevel: 1
+activitylevel: 10
 character:
   name: rat
   description: 'The rats sleek, mottled fur, a mix of dark browns and grays, allows it to blend seamlessly with the cobblestones and discarded refuse. Beady, black eyes dart around constantly, always on the lookout for both threats and opportunities. Its whiskers, long and sensitive, twitch with every new scent or vibration, guiding it through the labyrinthine backstreets. The rat''s tail, hairless and sinuous, trails behind it like a rudder, balancing its swift and erratic movements.'

--- a/_datafiles/mobs/frostfang/10-ivar_froststeel.yaml
+++ b/_datafiles/mobs/frostfang/10-ivar_froststeel.yaml
@@ -9,7 +9,7 @@ idlecommands:
   - 'say If you''re looking to sell something, I may be interested... as long as it''s not too special or unique'
   - emote is counting his coins
   - emote watches you carefully
-activitylevel: 1
+activitylevel: 10
 character:
   name: ivar froststeel
   description: 'Ivar Froststeel, the proprietor of Frostfang Armory, is a towering figure swathed in fur-lined leathers and adorned with intricate silver jewelry. His long, silver hair flows down his back, and a well-groomed beard frames his stern, yet wise face. His piercing blue eyes, reminiscent of glacial ice, seem to assess the worthiness of each customer who steps through the door.'

--- a/_datafiles/mobs/frostfang/11-brynja_snowdeal.yaml
+++ b/_datafiles/mobs/frostfang/11-brynja_snowdeal.yaml
@@ -10,7 +10,7 @@ idlecommands:
   - emote shuffles some papers
   - emote is counting her coins
   - emote is watching you
-activitylevel: 1
+activitylevel: 10
 character:
   name: brynja snowdeal
   description: 'With a reputation for fair dealings and an uncanny ability to procure the rarest of items, Brynja is well-regarded among the Emporium''s patrons. Her quick wit and sharp tongue are as legendary as her bargaining skills, ensuring that negotiations with Brynja are always an interesting affair. Despite her tough exterior, she possesses a keen sense of her customers'' needs, often pointing them towards the item they didn''t even realize they were looking for.'

--- a/_datafiles/mobs/frostfang/12-big_rat.yaml
+++ b/_datafiles/mobs/frostfang/12-big_rat.yaml
@@ -10,7 +10,7 @@ idlecommands:
   - 'emote glares at you'
   - 'wander'
   - ''
-activitylevel: 1
+activitylevel: 10
 character:
   name: big rat
   description: 'The imposing figure of the big rat dominates the dimly lit alley, its bulky form covered in a dense coat of glossy fur, interspersed with streaks of dark brown and sooty gray. Its large, beady eyes, reflecting a glint of cunning intelligence, survey the surroundings with a keen awareness, missing nothing. The big rat''s substantial whiskers, thick and highly sensitive, quiver at the slightest change in the air, navigating its formidable bulk through the narrow spaces with surprising agility. Its tail, thick and muscular, swings behind it like a pendulum, providing balance to its robust frame as it maneuvers with an unexpected grace. The big rat, a master of its domain, commands respect and attention in the shadowy world it inhabits.'

--- a/_datafiles/mobs/frostfang/2-guard.yaml
+++ b/_datafiles/mobs/frostfang/2-guard.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 20
 groups: 
   - frostfang-npc
-activitylevel: 2
+activitylevel: 20
 character:
   name: guard
   description: 'Standing tall and vigilant, the guard of Frostfang exudes an aura of unwavering duty. Clad in a thick, deep-blue cape that flutters against the biting wind, the guard''s silhouette is a familiar sight against the snowy backdrop of the city. The cape, adorned with the emblem of Frostfang, shields a suit of polished chainmail that gleams faintly in the dim light. Resting securely at the guard''s side is a broadsword, its blade well-maintained and sharp, a testament to the guard''s readiness. The guard''s eyes, hardened by the challenges of the frozen city, constantly scan the surroundings, ensuring the safety of its inhabitants and maintaining the order that Frostfang is known for.'

--- a/_datafiles/mobs/frostfang/26-frostfang_citizen.yaml
+++ b/_datafiles/mobs/frostfang/26-frostfang_citizen.yaml
@@ -4,7 +4,7 @@ itemdropchance: 2
 hostile: false
 groups: 
   - frostfang-npc
-activitylevel: 3
+activitylevel: 30
 maxwander: 5
 idlecommands:
   - 'wander'

--- a/_datafiles/mobs/frostfang/3-captain_of_the_guard.yaml
+++ b/_datafiles/mobs/frostfang/3-captain_of_the_guard.yaml
@@ -12,7 +12,7 @@ idlecommands:
   - 'wander'
   - 'wander'
   - 'wander'
-activitylevel: 5
+activitylevel: 50
 character:
   name: captain of the guard
   description: 'With an imposing stature and an air of seasoned authority, the captain of the Frostfang Guard stands out even amidst the city''s most formidable defenders. Draped over their armor is a rich, deep-blue cape, longer and more ornate than those of the regular guards, with gold embroidery tracing the edges and the emblem of Frostfang prominently displayed. Beneath the cape, a suit of intricately designed plate armor, bearing the scars of countless battles, speaks to the captain''s experience in the line of duty. Slung across their back is a masterfully crafted broadsword, its hilt adorned with gemstones. The blade itself is etched with delicate decorations, each one commemorating the momentous occasion of their promotion to captaincy. The captain''s gaze, sharp and discerning, misses no detail, and their perception alone is enough to inspire confidence and respect among both guards and citizens alike.'

--- a/_datafiles/mobs/frostfang/38-player_guide.yaml
+++ b/_datafiles/mobs/frostfang/38-player_guide.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 0
 groups: 
   - frostfang-npc
-activitylevel: 1
+activitylevel: 10
 character:
   name: player guide
   description: 'In combat, the Guide proves to be a steadfast protector, always ready to lend a helping hand when danger looms. They are a skilled warrior, wielding their frost-forged weapon with precision and using their keen senses to anticipate threats. New players can rely on the Guide to watch their back in the heat of battle, providing both tactical advice and unwavering support to ensure their safety.'

--- a/_datafiles/mobs/frostfang/39-elara.yaml
+++ b/_datafiles/mobs/frostfang/39-elara.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 0
 groups: 
   - frostfang-npc
-activitylevel: 2
+activitylevel: 20
 character:
   name: elara
   description: 'Elara is a tall, slender figure, exuding an aura of serene wisdom. Her skin is as pale as the snow-covered streets of Frostfang, and her long, silver hair flows down her back like a waterfall of ice. She dresses in elegant, deep blue robes adorned with silver embroidery depicting ancient runes and frost patterns. Her piercing blue eyes hold a glint of ancient knowledge, and her movements are graceful yet deliberate, as if she glides on an unseen layer of ice.'

--- a/_datafiles/mobs/frostfang/4-clergyman.yaml
+++ b/_datafiles/mobs/frostfang/4-clergyman.yaml
@@ -9,7 +9,7 @@ idlecommands:
   - 'emote chants quietly under his breath'
   - 'say Have you taken the time to help the poor today?'
   - ''
-activitylevel: 1
+activitylevel: 10
 character:
   name: clergyman
   description: 'Cloaked in robes of pristine white, interwoven with threads of silver that shimmer softly in the ambient light, stands the clergyman of the Sanctuary of the Benevolent Heart. The robe, cinched at the waist with a braided belt of deep blue, cascades down to the ground, its hem just brushing the floor. Around their neck, a pendant bearing the emblem of the Sanctuary—a heart cradled by two outstretched hands—rests as a testament to their sacred vows. Their hands, often clasped in prayer or offering aid, show signs of wear from years of service to the needy. The clergyman''s face, framed by a hood that casts a gentle shadow over their eyes, carries an expression of serene compassion, their gaze always filled with understanding and empathy. Their very perception emanates an aura of solace and hope, offering refuge to all who seek the Sanctuary''s embrace.'

--- a/_datafiles/mobs/frostfang/42-master_at_arms.yaml
+++ b/_datafiles/mobs/frostfang/42-master_at_arms.yaml
@@ -11,7 +11,7 @@ idlecommands:
   - 'emote eyes you with a critical gaze'
   - 'say I can teach you a few things about combat.'
   - 'say The difference between a good fighter and a great fighter is discipline.'
-activitylevel: 5
+activitylevel: 50
 character:
   name: master-at-arms
   description: 'he Master-at-Arms is a seasoned warrior and expert in medieval weaponry, charged with the crucial role of training soldiers and adventurers in the arts of combat. Known for their unparalleled skill with a variety of weapons, from swords and axes to bows and polearms, they possess not only physical prowess but also deep strategic knowledge of battlefield tactics. In the halls of the castle or the dusty training grounds, the Master-at-Arms commands respect and authority, shaping novices into formidable fighters. Their keen eye for technique, relentless discipline, and unwavering commitment to the art of war make them an invaluable asset to any lord or commander seeking to strengthen their forces.'

--- a/_datafiles/mobs/frostfang/5-armorer.yaml
+++ b/_datafiles/mobs/frostfang/5-armorer.yaml
@@ -10,7 +10,7 @@ idlecommands:
   - emote shuffles some papers
   - emote is counting his coins
   - emote is watching you
-activitylevel: 1
+activitylevel: 10
 character:
   name: armorer
   description: 'Nestled amidst the vibrant array of goods and trinkets, the shop merchant conducts business with a keen eye and a persuasive charm. Their attire is a mix of practicality and flair, with a well-tailored vest displaying an array of intricate patterns that catch the eye. A multitude of pouches and pockets are strategically placed, holding an assortment of small items ready to be showcased to potential buyers. Their hair is neatly combed, and a pair of spectacles rests on the bridge of their nose, aiding in the appraisal of goods and coins alike. With a welcoming smile and a practiced sales pitch, they engage customers, showcasing their wares with a flair for highlighting each item''s unique qualities. Their hands, nimble and precise, handle the merchandise with care, ensuring that even the most delicate of items are presented in the best possible light. The merchant''s knowledge of their inventory is extensive, and they are always ready to provide recommendations or share interesting tidbits about the origins of their goods. With a sharp mind for business and a genuine enthusiasm for their trade, the shop merchant creates an inviting and engaging shopping experience for all.'

--- a/_datafiles/mobs/frostfang/50-moilyn_the_wizard.yaml
+++ b/_datafiles/mobs/frostfang/50-moilyn_the_wizard.yaml
@@ -6,7 +6,7 @@ groups:
   - frostfang-npc
 idlecommands:
   - 'say type `list` to see what magical objects I have for sale'
-activitylevel: 1
+activitylevel: 10
 character:
   name: moilyn the wizard
   description: 'Nestled amidst the vibrant array of goods and trinkets, the shop merchant conducts business with a keen eye and a persuasive charm. Their attire is a mix of practicality and flair, with a well-tailored vest displaying an array of intricate patterns that catch the eye. A multitude of pouches and pockets are strategically placed, holding an assortment of small items ready to be showcased to potential buyers. Their hair is neatly combed, and a pair of spectacles rests on the bridge of their nose, aiding in the appraisal of goods and coins alike. With a welcoming smile and a practiced sales pitch, they engage customers, showcasing their wares with a flair for highlighting each item''s unique qualities. Their hands, nimble and precise, handle the merchandise with care, ensuring that even the most delicate of items are presented in the best possible light. The merchant''s knowledge of their inventory is extensive, and they are always ready to provide recommendations or share interesting tidbits about the origins of their goods. With a sharp mind for business and a genuine enthusiasm for their trade, the shop merchant creates an inviting and engaging shopping experience for all.'

--- a/_datafiles/mobs/frostfang/6-trainer.yaml
+++ b/_datafiles/mobs/frostfang/6-trainer.yaml
@@ -7,7 +7,7 @@ groups:
 idlecommands:
   - 'say I can help you <ansi fg="command">train</ansi> new skills!'
   - 'say There are other trainers to be found in the world, with other skills to teach you.'
-activitylevel: 1
+activitylevel: 10
 character:
   name: trainer
   description: 'Standing amidst the hustle and bustle of the training grounds, the trainer showcases seasoned expertise and unwavering patience. Their attire is practical and well-worn, with reinforced padding at key points to endure the rigors of demonstrating combat techniques and survival skills. A myriad of tools and weapons are slung across their belt and back, each one showcasing their wide-ranging knowledge and ability to adapt to any teaching scenario. Their eyes, sharp and observant, miss no detail as they guide adventurers through complex drills and exercises, offering constructive feedback and encouragement with a firm yet kind voice. The trainer’s hands, calloused and steady, deftly demonstrate each skill with precision and ease, ensuring that even the greenest of adventurers can grasp the fundamentals. With a deep well of patience and a genuine passion for helping others grow, the trainer stands as a pillar of support and guidance in the adventurers'' journey towards mastery.'

--- a/_datafiles/mobs/frostfang/7-wench.yaml
+++ b/_datafiles/mobs/frostfang/7-wench.yaml
@@ -7,7 +7,7 @@ groups:
 idlecommands:
   - 'say You can <ansi fg="command">sleep</ansi> here for a bit here to refresh.'
   - 'say If you''re hungry check the <ansi fg="command">list</ansi> of food for sale.'
-activitylevel: 1
+activitylevel: 10
 character:
   name: wench
   description: 'In the lively atmosphere of the inn, a serving wench navigates through the bustling crowd with grace and efficiency. Her attire is simple yet practical, consisting of a sturdy bodice and a flowing skirt that allows her to move freely as she attends to the patrons. Her hair is pulled back into a neat bun, with a few stray curls framing her cheerful face. With a tray balanced expertly in one hand, she deftly maneuvers around tables and chairs, delivering frothing mugs of ale and plates of hearty food with a warm smile and a kind word. Her laughter is infectious, brightening the mood of the room as she shares a quick joke or a playful tease. Despite the demanding nature of her work, she maintains a positive and resilient demeanor, ensuring that every guest feels welcome and well-cared for. Her keen eye and attentive nature make her quick to notice when a patron''s mug is empty or when a new arrival is in need of service, making her an invaluable perception in the bustling inn.'

--- a/_datafiles/mobs/frostfang_slums/28-ruffian.yaml
+++ b/_datafiles/mobs/frostfang_slums/28-ruffian.yaml
@@ -7,7 +7,7 @@ groups:
   - slum-ruffians
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: ruffian
   description: 'The ruffian looms in the dimly lit alleyway of the slums, a menacing figure carved out of the shadows. His rough, weather-beaten face is partly obscured by a tattered hood, but his eyes gleam with a predatory sharpness, scanning the surroundings with a mix of suspicion and brazen confidence. Broad-shouldered and solidly built, his presence is intimidating, the result of a life hardened by the unforgiving streets of the slums. His clothes are a patchwork of leather and cloth, well-worn and stained, telling a silent tale of numerous brawls and escapades.'

--- a/_datafiles/mobs/frostfang_slums/29-dangerous_ruffian.yaml
+++ b/_datafiles/mobs/frostfang_slums/29-dangerous_ruffian.yaml
@@ -5,7 +5,7 @@ hostile: true
 maxwander: 3
 idlecommands:
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 groups: 
   - slum-ruffians
 character:

--- a/_datafiles/mobs/frostfang_slums/30-shadow_master.yaml
+++ b/_datafiles/mobs/frostfang_slums/30-shadow_master.yaml
@@ -3,7 +3,7 @@ zone: Frostfang Slums
 itemdropchance: 5
 hostile: false
 maxwander: 0
-activitylevel: 1
+activitylevel: 10
 groups: 
   - slum-ruffians
 combatcommands:

--- a/_datafiles/mobs/frostfang_slums/31-junkyard_dog.yaml
+++ b/_datafiles/mobs/frostfang_slums/31-junkyard_dog.yaml
@@ -3,7 +3,7 @@ zone: Frostfang Slums
 itemdropchance: 5
 hostile: false
 maxwander: 0
-activitylevel: 1
+activitylevel: 10
 groups: 
   - slum-ruffians
 character:

--- a/_datafiles/mobs/frostfang_slums/40-rodric.yaml
+++ b/_datafiles/mobs/frostfang_slums/40-rodric.yaml
@@ -7,7 +7,7 @@ idlecommands:
   - 'wander'
 groups: 
   - frostfang-npc
-activitylevel: 2
+activitylevel: 20
 character:
   name: Rodric
   description: 'Rodric Greystone, known throughout Frostfang as the "Rat King," is a rugged, muscular man in his mid-thirties. His wild, unkempt hair and beard are flecked with gray, giving him a slightly feral appearance. He wears a patchwork of thick furs and leather armor, patched together from various scavenged materials. His piercing green eyes seem to see everything in the shadows, and his face bears the weathered look of someone who has spent many nights in the city''s darkest corners. He carries a sturdy staff tipped with iron, adorned with tiny bells that jingle softly with his movements.'

--- a/_datafiles/mobs/frostfang_slums/41-shadow_trainee.yaml
+++ b/_datafiles/mobs/frostfang_slums/41-shadow_trainee.yaml
@@ -3,7 +3,7 @@ zone: Frostfang Slums
 itemdropchance: 5
 hostile: false
 maxwander: 0
-activitylevel: 1
+activitylevel: 10
 groups: 
   - slum-ruffians
 combatcommands:

--- a/_datafiles/mobs/mirror_caves/22-cave_creeper.yaml
+++ b/_datafiles/mobs/mirror_caves/22-cave_creeper.yaml
@@ -8,7 +8,7 @@ groups:
 idlecommands:
   - 'emote writhes in the darkness.'
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: cave creeper
   description: 'Dwelling in the deepest parts of the caves, these tentacled horrors can extend their limbs great distances to ensnare prey. They are sensitive to light and often retreat into the abyssal cracks and crevices of the cave.'

--- a/_datafiles/mobs/mirror_caves/23-echo_bats.yaml
+++ b/_datafiles/mobs/mirror_caves/23-echo_bats.yaml
@@ -8,7 +8,7 @@ groups:
 idlecommands:
   - 'emote hangs from the ceiling.'
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: echo bats
   description: 'Navigating through echolocation, these oversized bats swarm in the darker recesses of the caves.'

--- a/_datafiles/mobs/mirror_caves/24-cave_stalker.yaml
+++ b/_datafiles/mobs/mirror_caves/24-cave_stalker.yaml
@@ -16,7 +16,7 @@ combatcommands:
   - 'sneak'
   - 'sneak;;;backstab'
   - 'sneak;;;backstab'
-activitylevel: 8
+activitylevel: 80
 character:
   name: cave stalker
   description: 'Stealthy and agile, these lizard-like predators blend seamlessly into the rocky environment.'

--- a/_datafiles/mobs/mirror_caves/25-abyssal_creeper.yaml
+++ b/_datafiles/mobs/mirror_caves/25-abyssal_creeper.yaml
@@ -8,7 +8,7 @@ groups:
 idlecommands:
   - 'emote writhes in the darkness.'
   - 'wander'
-activitylevel: 1
+activitylevel: 10
 character:
   name: abyssal creeper
   description: 'Dwelling in the deepest parts of the caves, these tentacled horrors can extend their limbs great distances to ensnare prey. They are sensitive to light and often retreat into the abyssal cracks and crevices of the cave.'

--- a/_datafiles/mobs/mystarion/45-mystarion_citizen.yaml
+++ b/_datafiles/mobs/mystarion/45-mystarion_citizen.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 20
 groups: 
   - mystarion-npc
-activitylevel: 4
+activitylevel: 40
 idlecommands:
   - 'emote casually looks around.'
 combatcommands:

--- a/_datafiles/mobs/mystarion/46-herbalist.yaml
+++ b/_datafiles/mobs/mystarion/46-herbalist.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 20
 groups: 
   - mystarion-npc
-activitylevel: 4
+activitylevel: 40
 idlecommands:
   - say type `list` to see my wares
   - say If you're looking to sell something, I may be interested... as long as it's

--- a/_datafiles/mobs/mystarion/47-brewer.yaml
+++ b/_datafiles/mobs/mystarion/47-brewer.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 20
 groups: 
   - mystarion-npc
-activitylevel: 4
+activitylevel: 40
 idlecommands:
   - say type `list` to see my wares
   - say If you're looking to sell something, I may be interested... as long as it's

--- a/_datafiles/mobs/mystarion/48-gardener.yaml
+++ b/_datafiles/mobs/mystarion/48-gardener.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 20
 groups: 
   - mystarion-npc
-activitylevel: 4
+activitylevel: 40
 idlecommands:
   - say type `list` to see my wares
   - say If you're looking to sell something, I may be interested... as long as it's

--- a/_datafiles/mobs/mystarion/49-henry_the_collector.yaml
+++ b/_datafiles/mobs/mystarion/49-henry_the_collector.yaml
@@ -5,7 +5,7 @@ hostile: false
 maxwander: 20
 groups: 
   - mystarion-npc
-activitylevel: 4
+activitylevel: 40
 idlecommands:
   - say type `list` to see my wares
   - say If you're looking to sell something, I may be interested... as long as it's

--- a/_datafiles/mobs/nowhere/59-blank_slate.yaml
+++ b/_datafiles/mobs/nowhere/59-blank_slate.yaml
@@ -3,7 +3,7 @@ zone: Nowhere
 itemdropchance: 0
 hostile: false
 maxwander: 0
-activitylevel: 1
+activitylevel: 10
 character:
   name: blank slate
   description: 'A blank slate.'

--- a/_datafiles/mobs/stormwatchers_keep/51-ice_warrior.yaml
+++ b/_datafiles/mobs/stormwatchers_keep/51-ice_warrior.yaml
@@ -1,7 +1,7 @@
 mobid: 51
 zone: Stormwatchers Keep
 itemdropchance: 4
-activitylevel: 3
+activitylevel: 30
 maxwander: 0
 character:
   name: ice warrior

--- a/_datafiles/mobs/stormwatchers_keep/52-ice_guardian.yaml
+++ b/_datafiles/mobs/stormwatchers_keep/52-ice_guardian.yaml
@@ -1,7 +1,7 @@
 mobid: 52
 zone: Stormwatchers Keep
 itemdropchance: 4
-activitylevel: 3
+activitylevel: 30
 maxwander: 0
 character:
   name: ice guardian

--- a/_datafiles/mobs/tutorial/57-orb_of_knowledge.yaml
+++ b/_datafiles/mobs/tutorial/57-orb_of_knowledge.yaml
@@ -3,7 +3,7 @@ zone: Tutorial
 itemdropchance: 0
 hostile: false
 maxwander: 0
-activitylevel: 1
+activitylevel: 10
 character:
   name: Orb of Knowledge
   description: 'The orb glows with inner awareness. Although it''s only a sphere of light, you can sense wisdom and intent.'

--- a/_datafiles/mobs/tutorial/58-training_dummy.yaml
+++ b/_datafiles/mobs/tutorial/58-training_dummy.yaml
@@ -3,7 +3,7 @@ zone: Tutorial
 itemdropchance: 0
 hostile: false
 maxwander: 0
-activitylevel: 1
+activitylevel: 10
 character:
   name: training dummy
   description: 'A wooden dummy to practice hitting.'

--- a/_datafiles/mobs/whispering_wastes/27-hermit.yaml
+++ b/_datafiles/mobs/whispering_wastes/27-hermit.yaml
@@ -1,7 +1,7 @@
 mobid: 27
 zone: Whispering Wastes
 itemdropchance: 2
-activitylevel: 3
+activitylevel: 30
 maxwander: 0
 character:
   name: hermit

--- a/_datafiles/mobs/whispering_wastes/54-snow_floof.yaml
+++ b/_datafiles/mobs/whispering_wastes/54-snow_floof.yaml
@@ -1,7 +1,7 @@
 mobid: 54
 zone: Whispering Wastes
 itemdropchance: 2
-activitylevel: 8
+activitylevel: 80
 maxwander: 4
 idlecommands:
   - 'emote stares up with its large, shiny eyes.'

--- a/_datafiles/mobs/whispering_wastes/55-snow_wolf.yaml
+++ b/_datafiles/mobs/whispering_wastes/55-snow_wolf.yaml
@@ -3,7 +3,7 @@ zone: Whispering Wastes
 itemdropchance: 1
 hostile: false
 maxwander: 5
-activitylevel: 1
+activitylevel: 10
 character:
   name: snow wolf
   description: 'The Snow Wolf is a fearsome predator that roams the frozen expanse of the Whispering Wastes, its thick, silver-gray fur allowing it to blend into the harsh, snow-covered landscape. Taller and more muscular than its warmer-climate cousins, the Snow Wolf has adapted to the brutal cold with an imposing frame and long, powerful limbs built for traversing deep snow. Its piercing yellow eyes seem to glow in the dim light of the Wastes'' endless winter, and its howl—low and mournful—can be heard echoing across the tundra, signaling the presence of its tightly-knit pack. Known for their intelligence and cunning, Snow Wolves are formidable hunters, able to track prey for days through fierce blizzards, using the winds and ice to their advantage.'

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -25,32 +25,34 @@ const (
 )
 
 type Config struct {
-	Version                      ConfigString      `yaml:"Version"` // Cuurrent version of all datafiles
-	MaxCPUCores                  ConfigInt         `yaml:"MaxCPUCores"`
-	FolderItemData               ConfigString      `yaml:"FolderItemData"`
-	FolderAttackMessageData      ConfigString      `yaml:"FolderAttackMessageData"`
-	FolderUserData               ConfigString      `yaml:"FolderUserData"`
-	FolderSpellData              ConfigString      `yaml:"FolderSpellData"`
-	FolderTemplates              ConfigString      `yaml:"FolderTemplates"`
-	FolderConversations          ConfigString      `yaml:"FolderConversations"`
-	FileAnsiAliases              ConfigString      `yaml:"FileAnsiAliases"`
-	FileColorPatterns            ConfigString      `yaml:"FileColorPatterns"`
-	FileKeywords                 ConfigString      `yaml:"FileKeywords"`
-	AllowItemBuffRemoval         ConfigBool        `yaml:"AllowItemBuffRemoval"`
-	CarefulSaveFiles             ConfigBool        `yaml:"CarefulSaveFiles"`
-	AuctionsEnabled              ConfigBool        `yaml:"AuctionsEnabled"`
-	AuctionsAnonymous            ConfigBool        `yaml:"AuctionsAnonymous"`
-	AuctionSeconds               ConfigInt         `yaml:"AuctionSeconds"`
-	AuctionUpdateSeconds         ConfigInt         `yaml:"AuctionUpdateSeconds"`
-	PVP                          ConfigString      `yaml:"PVP"`
-	PVPMinimumLevel              ConfigInt         `yaml:"PVPMinimumLevel"`
-	XPScale                      ConfigFloat       `yaml:"XPScale"`
-	TurnMs                       ConfigInt         `yaml:"TurnMs"`
-	RoundSeconds                 ConfigInt         `yaml:"RoundSeconds"`
-	RoundsPerAutoSave            ConfigInt         `yaml:"RoundsPerAutoSave"`
-	RoundsPerDay                 ConfigInt         `yaml:"RoundsPerDay"` // How many rounds are in a day
-	NightHours                   ConfigInt         `yaml:"NightHours"`   // How many hours of night
-	MaxMobBoredom                ConfigInt         `yaml:"MaxMobBoredom"`
+	Version                 ConfigString `yaml:"Version"` // Cuurrent version of all datafiles
+	MaxCPUCores             ConfigInt    `yaml:"MaxCPUCores"`
+	FolderItemData          ConfigString `yaml:"FolderItemData"`
+	FolderAttackMessageData ConfigString `yaml:"FolderAttackMessageData"`
+	FolderUserData          ConfigString `yaml:"FolderUserData"`
+	FolderSpellData         ConfigString `yaml:"FolderSpellData"`
+	FolderTemplates         ConfigString `yaml:"FolderTemplates"`
+	FolderConversations     ConfigString `yaml:"FolderConversations"`
+	FileAnsiAliases         ConfigString `yaml:"FileAnsiAliases"`
+	FileColorPatterns       ConfigString `yaml:"FileColorPatterns"`
+	FileKeywords            ConfigString `yaml:"FileKeywords"`
+	AllowItemBuffRemoval    ConfigBool   `yaml:"AllowItemBuffRemoval"`
+	CarefulSaveFiles        ConfigBool   `yaml:"CarefulSaveFiles"`
+	AuctionsEnabled         ConfigBool   `yaml:"AuctionsEnabled"`
+	AuctionsAnonymous       ConfigBool   `yaml:"AuctionsAnonymous"`
+	AuctionSeconds          ConfigInt    `yaml:"AuctionSeconds"`
+	AuctionUpdateSeconds    ConfigInt    `yaml:"AuctionUpdateSeconds"`
+	PVP                     ConfigString `yaml:"PVP"`
+	PVPMinimumLevel         ConfigInt    `yaml:"PVPMinimumLevel"`
+	XPScale                 ConfigFloat  `yaml:"XPScale"`
+	TurnMs                  ConfigInt    `yaml:"TurnMs"`
+	RoundSeconds            ConfigInt    `yaml:"RoundSeconds"`
+	RoundsPerAutoSave       ConfigInt    `yaml:"RoundsPerAutoSave"`
+	RoundsPerDay            ConfigInt    `yaml:"RoundsPerDay"` // How many rounds are in a day
+	NightHours              ConfigInt    `yaml:"NightHours"`   // How many hours of night
+	MaxMobBoredom           ConfigInt    `yaml:"MaxMobBoredom"`
+	MobConverseChance       ConfigInt    `yaml:"MobConverseChance"` // Chance 1-100 of attempting to converse when idle
+
 	MobUnloadThreshold           ConfigInt         `yaml:"MobUnloadThreshold"`
 	RoomUnloadRounds             ConfigInt         `yaml:"RoomUnloadRounds"`
 	RoomUnloadThreshold          ConfigInt         `yaml:"RoomUnloadThreshold"`
@@ -499,6 +501,12 @@ func (c *Config) Validate() {
 
 	if c.MaxMobBoredom < 1 {
 		c.MaxMobBoredom = 150 // default
+	}
+
+	if c.MobConverseChance < 0 {
+		c.MobConverseChance = 0
+	} else if c.MobConverseChance > 100 {
+		c.MobConverseChance = 100
 	}
 
 	if c.MobUnloadThreshold < 0 {

--- a/internal/conversations/conversations.go
+++ b/internal/conversations/conversations.go
@@ -87,7 +87,8 @@ func AttemptConversation(initiatorMobId int, initatorInstanceId int, initiatorNa
 		}
 	}
 
-	conversationCounter[fmt.Sprintf(`%s:%d`, fileName, chosenIndex)] = conversationCounter[fmt.Sprintf(`%s:%d`, fileName, chosenIndex)] + 1
+	trackingTag := fmt.Sprintf(`%s:%d`, fileName, chosenIndex)
+	conversationCounter[trackingTag] = conversationCounter[trackingTag] + 1
 
 	conversationUniqueId++
 

--- a/internal/mobs/mobs.go
+++ b/internal/mobs/mobs.go
@@ -59,7 +59,7 @@ type Mob struct {
 	MobId           MobId
 	Zone            string   `yaml:"zone,omitempty"`
 	ItemDropChance  int      // chance in 100
-	ActivityLevel   int      `yaml:"activitylevel,omitempty"` // 1 - 10%, 10 = 100%
+	ActivityLevel   int      `yaml:"activitylevel,omitempty"` // 1-100%
 	InstanceId      int      `yaml:"-"`
 	HomeRoomId      int      `yaml:"-"`
 	Hostile         bool     // whether they attack on sight
@@ -564,11 +564,11 @@ func (r *Mob) Id() int {
 }
 
 func (r *Mob) Validate() error {
+
 	if r.ActivityLevel < 1 {
-		r.ActivityLevel = 1
-	}
-	if r.ActivityLevel > 10 {
 		r.ActivityLevel = 10
+	} else if r.ActivityLevel > 100 {
+		r.ActivityLevel = 100
 	}
 
 	r.hasConverseFile = conversations.HasConverseFile(int(r.MobId), r.Zone)

--- a/internal/web/admin.mobs.go
+++ b/internal/web/admin.mobs.go
@@ -78,7 +78,7 @@ func mobData(w http.ResponseWriter, r *http.Request) {
 	})
 
 	activityLevels := []int{}
-	for i := 0; i < 11; i++ {
+	for i := 1; i < 101; i++ {
 		activityLevels = append(activityLevels, i)
 	}
 


### PR DESCRIPTION
# Changes
* Config option added for MobConverseChance (0-100)
* Mob activity level now defined as 1-100 instead of 1-10
* Adjusted conversation processing to immediately call `Converse()` so that participating mobs don't simultaneously queue a wander command.