### PR TITLE
feat: Add ci/cd workflow to GoMud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,90 @@
+# This workflow will: build gomud for multiple os/architectures
+# archive the binaries and create a new release for users to easily download
+
+name: Go
+
+on:
+  push:
+    branches: ["master", "ci-cd-releases"]
+
+env:
+  RELEASE_FILENAME: go-mud-release
+
+jobs:
+  # test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Test
+  #       run: go test -v ./...
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
+
+      - name: Create bin directory
+        run: mkdir -p bin/
+
+      - name: Copy _datafiles to bin/
+        run: cp -r _datafiles bin/
+
+      - name: Build windows amd64
+        run: env GOOS=windows GOARCH=amd64 go build -v -o bin/go-mud-windows_x64.exe .
+
+      - name: Build darwin/arm64
+        run: env GOOS=darwin GOARCH=arm64 go build -v -o bin/go-mud-darwin_arm64 .
+
+      - name: Build darwin/amd64
+        run: env GOOS=darwin GOARCH=amd64 go build -v -o bin/go-mud-darwin_x64 .
+
+      - name: Build linux/amd64
+        run: env GOOS=linux GOARCH=amd64 go build -v -o bin/go-mud-linux_x64 .
+
+      - name: Build linux/arm5
+        run: env GOOS=linux GOARCH=arm GOARM=5 go build -v -o bin/go-mud-linux_arm5 .
+
+      - name: Upload bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-artifact
+          path: bin/
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download builds
+        uses: actions/download-artifact@v4
+        with:
+          name: bin-artifact
+          path: bin/
+
+      - name: Set short git commit SHA
+        id: vars
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+
+      - name: Archive release
+        uses: thedoctor0/zip-release@master
+        id: zip-binaries
+        with:
+          type: zip
+          directory: bin
+          filename: ${{ env.RELEASE_FILENAME }}-${{ env.COMMIT_SHORT_SHA }}.zip
+
+      - name: Release with notes
+        uses: softprops/action-gh-release@v1
+        with:
+          files: bin/${{ env.RELEASE_FILENAME }}-${{ env.COMMIT_SHORT_SHA }}.zip
+          tag_name: release-${{ env.COMMIT_SHORT_SHA }}
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 private-notes.txt
 **/users/*
 **/config-overrides.yaml
+bin/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![image](feature-screenshots/splash.png)
 
-GoMud is an in-development open source MUD (Multi-user Dungeon) game world and library. 
+GoMud is an in-development open source MUD (Multi-user Dungeon) game world and library.
 
 It ships with a default world to play in, but can be overwritten or modified to build your own world using built-in tools.
 
@@ -18,7 +18,7 @@ If you have comments, questions, suggestions:
 
 Click below to see in-game screenshots of just a handful of features:
 
-[![Feature Screenshots](feature-screenshots/screenshots-thumb.png 'Feature Screenshots')](feature-screenshots/README.md)
+[![Feature Screenshots](feature-screenshots/screenshots-thumb.png "Feature Screenshots")](feature-screenshots/README.md)
 
 ## ANSI Colors
 
@@ -48,16 +48,18 @@ Information on scripting in GoMud can be found in the [scripting README](scripti
 
 # Quick Start
 
+You can download the latest release from the [releases page](https://github.com/Volte6/GoMud/releases), unzip it and run the binary to get started, or if you prefer to build it yourself, follow the instructions below.
+
 A youtube playlist to getting started has been set up here:
 
-
-[![Getting Started Videos](https://i.ytimg.com/vi/OOZqX01aHt8/hqdefault.jpg 'Getting Started Playlist')](https://www.youtube.com/watch?v=OOZqX01aHt8&list=PL20JEmG_bxBuaOE9oFziAhAmx1pyXhQ1p)
-
+[![Getting Started Videos](https://i.ytimg.com/vi/OOZqX01aHt8/hqdefault.jpg "Getting Started Playlist")](https://www.youtube.com/watch?v=OOZqX01aHt8&list=PL20JEmG_bxBuaOE9oFziAhAmx1pyXhQ1p)
 
 You can compile and run it locally with:
+
 > `go run .`
 
 Or you can just build the binary if you prefer:
+
 > `go build -o GoMudServer`
 
 > `./GoMudServer`
@@ -68,9 +70,9 @@ Or if you have docker installed:
 
 ## Connecting
 
-*TELNET* : connect to `localhost` on port `33333` with a telnet client
+_TELNET_ : connect to `localhost` on port `33333` with a telnet client
 
-*WEB CLIENT*: [http://localhost/webclient](http://localhost/webclient) 
+_WEB CLIENT_: [http://localhost/webclient](http://localhost/webclient)
 
 **Default Username:** _admin_
 
@@ -80,22 +82,22 @@ Or if you have docker installed:
 
 When running several environment variables can be set to alter behaviors of the mud:
 
-* **CONFIG_PATH**_=/path/to/alternative/config.yaml_ - This can provide a path to a copy of the config.yaml containing only values you wish to override. This way you don't have to modify the original config.yaml
-* **LOG_PATH**_=/path/to/log.txt_ - This will write all logs to a specified file. If unspecified, will write to *stderr*.
-* **LOG_LEVEL**_={LOW/MEDIUM/HIGH}_ - This sets how verbose you want the logs to be. _(Note: Log files rotate every 100MB)_
+- **CONFIG_PATH**_=/path/to/alternative/config.yaml_ - This can provide a path to a copy of the config.yaml containing only values you wish to override. This way you don't have to modify the original config.yaml
+- **LOG_PATH**_=/path/to/log.txt_ - This will write all logs to a specified file. If unspecified, will write to _stderr_.
+- **LOG_LEVEL**_={LOW/MEDIUM/HIGH}_ - This sets how verbose you want the logs to be. _(Note: Log files rotate every 100MB)_
 
 ## Platform specific
 
 ### Raspberry pi
 
-Want to run GoMud on a raspberry pi? No problem! I do it all the time! It runs great on a [$15 Raspberry Pi Zero 2](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/). However, in my experience the raspberry pi struggles to compile the binary directly, 
+Want to run GoMud on a raspberry pi? No problem! I do it all the time! It runs great on a [$15 Raspberry Pi Zero 2](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/). However, in my experience the raspberry pi struggles to compile the binary directly,
 so it is recommended that you compile the binary locally and then copy it over to the raspberry pi.
 
-There is a convenient `make` command to compile the pi chipset provided: 
+There is a convenient `make` command to compile the pi chipset provided:
 
 `make build_rpi` ( this will output a binary named: `go-mud-server-rpi` )
 
-Or (window user?) just use the build comand directly: 
+Or (window user?) just use the build comand directly:
 
 `env GOOS=linux GOARCH=arm GOARM=5 go build -o go-mud-server-rpi`
 
@@ -105,11 +107,11 @@ Why not?
 
 Go provides a lot of terrific benefits such as:
 
-* Compatible - High degree of compatibility across platforms or CPU Architectures. Go code quite painlessly compiles for Windows, Linux, ARM, etc. with minimal to no changes to the code.
-* Fast - Go is fast. From execution to builds. The current GoMud project builds on a Macbook in less than a couple of seconds.
-* Opinionated - Go style and patterns are well established and provide a reliable way to dive into a project and immediately feel familiar with the style.
-* Modern - Go is a relatively new/modern language without the burden of "every feature people thought would be useful in the last 30 or 40 years" added to it. 
-* Upgradable -  Go's promise of maintaining backward compatibility means upgrading versions over time remains a simple and painless process (If not downright invisible).
-* Statically Linked - If you have the binary, you have the working program. Externally linked dependencies (and whether you have them) are not an issue.
-* No Central Registries - Go is built to naturally incorporate library includes straight from their repos (such as git). This is neato.
-* Concurrent - Go has concurrency built in as a feature of the language, not a library you include.
+- Compatible - High degree of compatibility across platforms or CPU Architectures. Go code quite painlessly compiles for Windows, Linux, ARM, etc. with minimal to no changes to the code.
+- Fast - Go is fast. From execution to builds. The current GoMud project builds on a Macbook in less than a couple of seconds.
+- Opinionated - Go style and patterns are well established and provide a reliable way to dive into a project and immediately feel familiar with the style.
+- Modern - Go is a relatively new/modern language without the burden of "every feature people thought would be useful in the last 30 or 40 years" added to it.
+- Upgradable - Go's promise of maintaining backward compatibility means upgrading versions over time remains a simple and painless process (If not downright invisible).
+- Statically Linked - If you have the binary, you have the working program. Externally linked dependencies (and whether you have them) are not an issue.
+- No Central Registries - Go is built to naturally incorporate library includes straight from their repos (such as git). This is neato.
+- Concurrent - Go has concurrency built in as a feature of the language, not a library you include.


### PR DESCRIPTION
This PR adds a CI/CD workflow to GoMud.

GoMud now automatically builds and release to branch changes to `master`.
This should make running the mud more approachable for less technically savvy users.
(It also appears my auto-linter went to town on the markdown file)