### PR TITLE
pre-merge-request-tests

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,14 +3,9 @@
 
 name: Build and release
 
-# on:
-#   push:
-#     branches: [master]
-#   workflow_dispatch:
-
 on:
   push:
-    branches: [pre-merge-testing]
+    branches: [master]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,11 +1,17 @@
 # This workflow will: build gomud for multiple os/architectures
 # archive the binaries and create a new release for users to easily download
 
-name: Go
+name: Build and release
+
+# on:
+#   push:
+#     branches: [master]
+#   workflow_dispatch:
 
 on:
   push:
-    branches: ["master", "ci-cd-releases"]
+    branches: [pre-merge-testing]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,14 +20,22 @@ env:
   RELEASE_FILENAME: go-mud-release
 
 jobs:
-  # test:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Test
-  #       run: go test -v ./...
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
+
+      - name: Run tests
+        run: go test ./...
 
   build:
     runs-on: ubuntu-latest
+    needs: "test"
     steps:
       - uses: actions/checkout@v4
 
@@ -59,7 +73,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: "build"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,13 +1,8 @@
 name: run-tests
 
-# on:
-#   pull_request:
-#     branches: [master]
-#   workflow_dispatch:
-
 on:
-  push:
-    branches: [pre-merge-testing]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,25 @@
+name: run-tests
+
+# on:
+#   pull_request:
+#     branches: [master]
+#   workflow_dispatch:
+
+on:
+  push:
+    branches: [pre-merge-testing]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
+
+      - name: Run tests
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 private-notes.txt
 **/users/*
 **/config-overrides.yaml
-bin/

--- a/internal/just_a_test.go
+++ b/internal/just_a_test.go
@@ -1,0 +1,15 @@
+package internal
+
+import (
+    "testing"
+)
+
+func TestShouldPass(t *testing.T) {
+	if 1 != 1 {
+		t.Fatalf("Something is wrong in the universe...")
+	}
+}
+
+func TestShouldFail(t *testing.T) {
+	//t.Fatalf("TestShouldFail failed.")
+}


### PR DESCRIPTION
This PR adds a new ci/cd workflow that runs when a PR is made against `master`.

You will (likely) want to enable a few repository options in github to ensure this isn't bypassed, but it's up to you:

- Branch protection on `master` which requires a PR to merge
- CI/CD must pass before merging a PR