### PR TITLE
Room edit mutators command.

### DIFF
--- a/_datafiles/world/default/templates/admincommands/help/command.room.template
+++ b/_datafiles/world/default/templates/admincommands/help/command.room.template
@@ -37,6 +37,9 @@ Set a property of the room. This updates basic properties of the room you are in
     Exits:
         You can interactively add/remove/edit exits using the command:
         <ansi fg="command">room edit exits</ansi>
+    Mutators:
+        You can interactively add/remove mutators to the room using the command:
+        <ansi fg="command">room edit mutators</ansi>
 
 <ansi fg="command">room exit [exit_name] [room_id]</ansi> - e.g. <ansi fg="command">room exit west 159</ansi>
 This will create a new exit that links to a specific room_id using the exit_name provided.

--- a/_datafiles/world/empty/templates/admincommands/help/command.room.template
+++ b/_datafiles/world/empty/templates/admincommands/help/command.room.template
@@ -37,6 +37,9 @@ Set a property of the room. This updates basic properties of the room you are in
     Exits:
         You can interactively add/remove/edit exits using the command:
         <ansi fg="command">room edit exits</ansi>
+    Mutators:
+        You can interactively add/remove mutators to the room using the command:
+        <ansi fg="command">room edit mutators</ansi>
 
 <ansi fg="command">room exit [exit_name] [room_id]</ansi> - e.g. <ansi fg="command">room exit west 159</ansi>
 This will create a new exit that links to a specific room_id using the exit_name provided.


### PR DESCRIPTION
# Changes
* `room edit mutators` command added
  * Provides a basic way to toggle on/off multiple mutators for the room
    * Note: NOT THE ZONE.
* Added a toggle for `room edit exit` to set exits to secret/hidden. 