### PR TITLE
Room Exit Messages

### DIFF
--- a/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
+++ b/_datafiles/guides/building/scripting/FUNCTIONS_ACTORS.md
@@ -29,7 +29,8 @@ ActorObjects are the basic object that represents Users and NPCs
   - [ActorObject.AddGold(amt int \[, bankAmt int\])](#actorobjectaddgoldamt-int--bankamt-int)
   - [ActorObject.AddHealth(amt int) int](#actorobjectaddhealthamt-int-int)
   - [ActorObject.Sleep(seconds int)](#actorobjectsleepseconds-int)
-  - [ActorObject.Command(cmd string, waitTurns ...int)](#actorobjectcommandcmd-string-waitturns-int)
+  - [ActorObject.Command(cmd string \[, waitTurns int\])](#actorobjectcommandcmd-string--waitturns-int)
+  - [ActorObject.CommandFlagged(cmd string, flag int \[, waitTurns int\])](#actorobjectcommandflaggedcmd-string-flag-int--waitturns-int)
   - [ActorObject.IsTameable() bool](#actorobjectistameable-bool)
   - [ActorObject.TrainSkill(skillName string, skillLevel int)](#actorobjecttrainskillskillname-string-skilllevel-int)
   - [ActorObject.GetSkillLevel(skillName string)](#actorobjectgetskilllevelskillname-string)
@@ -259,7 +260,7 @@ _Note: Only works on mobs._
 | --- | --- |
 | seconds | How many seconds to wait. |
 
-## [ActorObject.Command(cmd string, waitTurns ...int)](/internal/scripting/actor_func.go)
+## [ActorObject.Command(cmd string [, waitTurns int])](/internal/scripting/actor_func.go)
 Forces an ActorObject to execute a command as if they entered it
 
 _Note: Don't underestimate the power of this function! Complex and interesting behaviors or interactions can emerge from using it._
@@ -267,6 +268,18 @@ _Note: Don't underestimate the power of this function! Complex and interesting b
 |  Argument | Explanation |
 | --- | --- |
 | cmd | The command to execute such as `look west` or `say goodbye`. |
+| waitTurns (optional) | The number of turns (NOT rounds) to wait before executing the command. |
+
+## [ActorObject.CommandFlagged(cmd string, flag int [, waitTurns int])](/internal/scripting/actor_func.go)
+Forces an ActorObject to execute a command as if they entered it.
+WARNING: Advanced Usage. Required a flag integer.
+
+_Note: Don't underestimate the power of this function! Complex and interesting behaviors or interactions can emerge from using it._
+
+|  Argument | Explanation |
+| --- | --- |
+| cmd | The command to execute such as `look west` or `say goodbye`. |
+| flag | The special control flag to pass to the command. |
 | waitTurns (optional) | The number of turns (NOT rounds) to wait before executing the command. |
 
 ## [ActorObject.IsTameable() bool](/internal/scripting/actor_func.go)

--- a/_datafiles/world/default/users/admin.yaml
+++ b/_datafiles/world/default/users/admin.yaml
@@ -63,17 +63,17 @@ character:
     - buffid: 28
       onstartevent: true
       permabuff: true
-      roundcounter: 28
+      roundcounter: 23
       triggersleft: 1000000000
     - buffid: 29
       onstartevent: true
       permabuff: true
-      roundcounter: 36
+      roundcounter: 16
       triggersleft: 1000000000
     - buffid: 39
       onstartevent: false
       permabuff: true
-      roundcounter: 10
+      roundcounter: 5
       triggersleft: 1000000000
   equipment:
     weapon:

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -35,6 +35,7 @@ type Input struct {
 	MobInstanceId int
 	InputText     string
 	WaitTurns     int
+	Flags         uint64
 }
 
 func (i Input) Type() string { return `Input` }

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -16,6 +16,7 @@ type RoomExit struct {
 	RoomId       int
 	Secret       bool          `yaml:"secret,omitempty"`
 	MapDirection string        `yaml:"mapdirection,omitempty"` // Optionaly indicate the direction of this exit for mapping purposes
+	ExitMessage  string        `yaml:"exitmessage,omitempty"`  // If set, this message is sent to the user, followed by a delay, before they actually go through the exit.
 	Lock         gamelock.Lock `yaml:"lock,omitempty"`         // 0 - no lock. greater than zero = difficulty to unlock.
 }
 

--- a/internal/scripting/actor_func.go
+++ b/internal/scripting/actor_func.go
@@ -309,6 +309,17 @@ func (a ScriptActor) Command(cmd string, waitTurns ...int) {
 	}
 }
 
+func (a ScriptActor) CommandFlagged(cmd string, flags int, waitTurns ...int) {
+	if len(waitTurns) < 1 {
+		waitTurns = append(waitTurns, 0)
+	}
+	if a.userId > 0 {
+		a.userRecord.CommandFlagged(cmd, uint64(flags), waitTurns[0])
+	} else {
+		a.mobRecord.Command(cmd, waitTurns[0])
+	}
+}
+
 func (a ScriptActor) TrainSkill(skillName string, skillLevel int) bool {
 
 	if a.userRecord == nil {

--- a/internal/usercommands/README.md
+++ b/internal/usercommands/README.md
@@ -3,7 +3,7 @@
 The `usercommands` package defines a function type and contains all of the commands a user can enter.
 
 ```
-type UserCommand func(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
+type UserCommand func(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error)
 ```
 
 All commands follow that definition, where
@@ -13,7 +13,7 @@ All commands follow that definition, where
 
 ```
 
-func Glarble(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Glarble(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
     
     room.SendText(`This glarble text goes out to all players in room`)
 

--- a/internal/usercommands/admin.badcommands.go
+++ b/internal/usercommands/admin.badcommands.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func BadCommands(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func BadCommands(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "clear" {
 		badinputtracker.Clear()

--- a/internal/usercommands/admin.buff.go
+++ b/internal/usercommands/admin.buff.go
@@ -16,7 +16,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Buff(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Buff(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room

--- a/internal/usercommands/admin.build.go
+++ b/internal/usercommands/admin.build.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func IBuild(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func IBuild(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// args should look like one of the following:
 	// info <optional room id>
@@ -115,7 +115,7 @@ func IBuild(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 	return true, nil
 }
 
-func Build(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Build(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// args should look like one of the following:
 	// info <optional room id>

--- a/internal/usercommands/admin.command.go
+++ b/internal/usercommands/admin.command.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Command(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Command(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room

--- a/internal/usercommands/admin.deafen.go
+++ b/internal/usercommands/admin.deafen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Deafen(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Deafen(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.deafen", nil)
@@ -36,7 +36,7 @@ func Deafen(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 	return true, nil
 }
 
-func UnDeafen(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func UnDeafen(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.deafen", nil)

--- a/internal/usercommands/admin.grant.go
+++ b/internal/usercommands/admin.grant.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Grant(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Grant(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.grant", nil)

--- a/internal/usercommands/admin.item.go
+++ b/internal/usercommands/admin.item.go
@@ -16,7 +16,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Item(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Item(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Permission != users.PermissionAdmin {
 		user.SendText(`<ansi fg="alert-4">Only admins can use this command</ansi>`)
@@ -33,23 +33,23 @@ func Item(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// create a new item
 	if args[0] == `create` {
-		return item_Create(strings.TrimSpace(rest[6:]), user, room)
+		return item_Create(strings.TrimSpace(rest[6:]), user, room, flags)
 	}
 
 	// spawn an existing item
 	if args[0] == `spawn` {
-		return item_Spawn(strings.TrimSpace(rest[5:]), user, room)
+		return item_Spawn(strings.TrimSpace(rest[5:]), user, room, flags)
 	}
 
 	// List existing items
 	if args[0] == `list` {
-		return item_List(strings.TrimSpace(rest[4:]), user, room)
+		return item_List(strings.TrimSpace(rest[4:]), user, room, flags)
 	}
 
 	return true, nil
 }
 
-func item_List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func item_List(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	itmNames := []templates.NameDescription{}
 
@@ -80,7 +80,7 @@ func item_List(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 	return true, nil
 }
 
-func item_Spawn(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func item_Spawn(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	itemId := items.FindItem(rest)
 	if itemId != 0 {
@@ -109,7 +109,7 @@ func item_Spawn(rest string, user *users.UserRecord, room *rooms.Room) (bool, er
 	return true, nil
 }
 
-func item_Create(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func item_Create(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	var newItemSpec = items.ItemSpec{}
 

--- a/internal/usercommands/admin.locate.go
+++ b/internal/usercommands/admin.locate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Locate(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Locate(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.locate", nil)

--- a/internal/usercommands/admin.mob.go
+++ b/internal/usercommands/admin.mob.go
@@ -18,7 +18,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Mob(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Mob(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Permission != users.PermissionAdmin {
 		user.SendText(`<ansi fg="alert-4">Only admins can use this command</ansi>`)
@@ -35,23 +35,23 @@ func Mob(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Create a new mob
 	if args[0] == `create` {
-		return mob_Create(strings.TrimSpace(rest[6:]), user, room)
+		return mob_Create(strings.TrimSpace(rest[6:]), user, room, flags)
 	}
 
 	// Spawn a mob instance
 	if args[0] == `spawn` {
-		return mob_Spawn(strings.TrimSpace(rest[5:]), user, room)
+		return mob_Spawn(strings.TrimSpace(rest[5:]), user, room, flags)
 	}
 
 	// List existing mobs
 	if args[0] == `list` {
-		return mob_List(strings.TrimSpace(rest[4:]), user, room)
+		return mob_List(strings.TrimSpace(rest[4:]), user, room, flags)
 	}
 
 	return true, nil
 }
 
-func mob_List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func mob_List(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	mobNames := []templates.NameDescription{}
 
@@ -83,7 +83,7 @@ func mob_List(rest string, user *users.UserRecord, room *rooms.Room) (bool, erro
 	return true, nil
 }
 
-func mob_Spawn(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func mob_Spawn(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	c := configs.GetConfig()
 
@@ -127,7 +127,7 @@ func mob_Spawn(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 	return true, nil
 }
 
-func mob_Create(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func mob_Create(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	var newMob = mobs.Mob{}
 
@@ -220,7 +220,7 @@ func mob_Create(rest string, user *users.UserRecord, room *rooms.Room) (bool, er
 		}
 
 		question.RejectResponse()
-		return Help(helpCmd+` `+helpRest, user, room)
+		return Help(helpCmd+` `+helpRest, user, room, flags)
 	}
 
 	raceNameSelection := question.Response

--- a/internal/usercommands/admin.modify.go
+++ b/internal/usercommands/admin.modify.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Modify(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Modify(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Permission != users.PermissionAdmin {
 		user.SendText(`<ansi fg="alert-4">Only admins can use this command</ansi>`)

--- a/internal/usercommands/admin.mudmail.go
+++ b/internal/usercommands/admin.mudmail.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Mudmail(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Mudmail(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	/*
 		args := util.SplitButRespectQuotes(rest)

--- a/internal/usercommands/admin.mute.go
+++ b/internal/usercommands/admin.mute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Mute(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Mute(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.mute", nil)
@@ -36,7 +36,7 @@ func Mute(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 	return true, nil
 }
 
-func UnMute(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func UnMute(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.mute", nil)

--- a/internal/usercommands/admin.paz.go
+++ b/internal/usercommands/admin.paz.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Paz(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Paz(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	beamOfLight := colorpatterns.ApplyColorPattern(`beam of light`, `rainbow`)
 

--- a/internal/usercommands/admin.prepare.go
+++ b/internal/usercommands/admin.prepare.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Prepare(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Prepare(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.prepare", nil)

--- a/internal/usercommands/admin.questtoken.go
+++ b/internal/usercommands/admin.questtoken.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func QuestToken(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func QuestToken(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// args should look like one of the following:
 	// questtoken <tokenname>

--- a/internal/usercommands/admin.redescribe.go
+++ b/internal/usercommands/admin.redescribe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Redescribe(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Redescribe(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/internal/usercommands/admin.reload.go
+++ b/internal/usercommands/admin.reload.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Reload(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Reload(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.reload", nil)

--- a/internal/usercommands/admin.rename.go
+++ b/internal/usercommands/admin.rename.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Rename(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Rename(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/internal/usercommands/admin.server.go
+++ b/internal/usercommands/admin.server.go
@@ -19,7 +19,7 @@ var (
 	memoryReportCache = map[string]util.MemoryResult{}
 )
 
-func Server(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Server(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		infoOutput, _ := templates.Process("admincommands/help/command.server", nil)

--- a/internal/usercommands/admin.skillset.go
+++ b/internal/usercommands/admin.skillset.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Skillset(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Skillset(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// args should look like one of the following:
 	// target buffId - put buff on target if in the room

--- a/internal/usercommands/admin.spawn.go
+++ b/internal/usercommands/admin.spawn.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Spawn(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Spawn(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/internal/usercommands/admin.spell.go
+++ b/internal/usercommands/admin.spell.go
@@ -15,7 +15,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Spell(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Spell(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Permission != users.PermissionAdmin {
 		user.SendText(`<ansi fg="alert-4">Only admins can use this command</ansi>`)
@@ -32,18 +32,18 @@ func Spell(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 
 	// Create a new spell
 	if args[0] == `create` {
-		return spell_Create(strings.TrimSpace(rest[6:]), user, room)
+		return spell_Create(strings.TrimSpace(rest[6:]), user, room, flags)
 	}
 
 	// List existing spells
 	if args[0] == `list` {
-		return spell_List(strings.TrimSpace(rest[4:]), user, room)
+		return spell_List(strings.TrimSpace(rest[4:]), user, room, flags)
 	}
 
 	return true, nil
 }
 
-func spell_List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func spell_List(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	spellNames := []templates.NameDescription{}
 
@@ -75,7 +75,7 @@ func spell_List(rest string, user *users.UserRecord, room *rooms.Room) (bool, er
 	return true, nil
 }
 
-func spell_Create(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func spell_Create(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	var newSpell = spells.SpellData{}
 

--- a/internal/usercommands/admin.zap.go
+++ b/internal/usercommands/admin.zap.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Zap(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Zap(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	boltOfLightning := colorpatterns.ApplyColorPattern(`bolt of lightning`, `glowing`)
 

--- a/internal/usercommands/admin.zone.go
+++ b/internal/usercommands/admin.zone.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/volte6/gomud/internal/configs"
 	"github.com/volte6/gomud/internal/mutators"
 	"github.com/volte6/gomud/internal/rooms"
 	"github.com/volte6/gomud/internal/templates"
@@ -250,7 +251,12 @@ func zone_Edit(rest string, user *users.UserRecord, room *rooms.Room, flags User
 
 		if question.Response == `yes` {
 
-			question := cmdPrompt.Ask(`Zone music file?`, []string{editZoneConfig.MusicFile}, editZoneConfig.MusicFile)
+			relativeString := configs.GetConfig().MspFileUrl.String()
+			if len(relativeString) > 0 {
+				user.SendText(`   <ansi fg="red">Note:</ansi> Music file path must be relative to: <ansi fg="red">` + relativeString + `</ansi>`)
+			}
+
+			question := cmdPrompt.Ask(`Zone music file path?`, []string{editZoneConfig.MusicFile}, editZoneConfig.MusicFile)
 			if !question.Done {
 				return true, nil
 			}

--- a/internal/usercommands/admin.zone.go
+++ b/internal/usercommands/admin.zone.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Zone(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Zone(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	handled := true
 
@@ -35,7 +35,7 @@ func Zone(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	// Interactive Editing
 	if zoneCmd == `edit` {
-		return zone_Edit(``, user, room)
+		return zone_Edit(``, user, room, flags)
 	}
 
 	zoneConfig := rooms.GetZoneConfig(room.Zone)
@@ -100,7 +100,7 @@ func Zone(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 	return true, nil
 }
 
-func zone_Edit(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func zone_Edit(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	originalZoneConfig := rooms.GetZoneConfig(room.Zone)
 	if originalZoneConfig == nil {
@@ -243,11 +243,22 @@ func zone_Edit(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 	//
 	{
 
-		question := cmdPrompt.Ask(`Zone music file?`, []string{editZoneConfig.MusicFile}, editZoneConfig.MusicFile)
+		question := cmdPrompt.Ask(`Should the zone have music?`, []string{`yes`, `no`}, util.BoolYN(editZoneConfig.MusicFile != ``))
 		if !question.Done {
 			return true, nil
 		}
-		editZoneConfig.MusicFile = question.Response
+
+		if question.Response == `yes` {
+
+			question := cmdPrompt.Ask(`Zone music file?`, []string{editZoneConfig.MusicFile}, editZoneConfig.MusicFile)
+			if !question.Done {
+				return true, nil
+			}
+			editZoneConfig.MusicFile = question.Response
+
+		} else {
+			editZoneConfig.MusicFile = ``
+		}
 
 	}
 

--- a/internal/usercommands/alias.go
+++ b/internal/usercommands/alias.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Alias(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Alias(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// biuld array and look up table for sorting purposes
 	allOutCmds := []string{}

--- a/internal/usercommands/appraise.go
+++ b/internal/usercommands/appraise.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Appraise(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Appraise(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	for _, mobId := range room.GetMobs(rooms.FindMerchant) {
 

--- a/internal/usercommands/ask.go
+++ b/internal/usercommands/ask.go
@@ -14,7 +14,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Ask(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Ask(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// Core "useful" commands
 	usefulCommands := []string{

--- a/internal/usercommands/attack.go
+++ b/internal/usercommands/attack.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Attack(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Attack(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	attackPlayerId := 0
 	attackMobInstanceId := 0

--- a/internal/usercommands/auction.go
+++ b/internal/usercommands/auction.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Auction(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Auction(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if on := user.GetConfigOption(`auction`); on != nil && !on.(bool) {
 

--- a/internal/usercommands/bank.go
+++ b/internal/usercommands/bank.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Bank(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Bank(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	user.SendText(``)
 

--- a/internal/usercommands/biome.go
+++ b/internal/usercommands/biome.go
@@ -8,7 +8,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Biome(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Biome(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	biome, ok := rooms.GetBiome(room.Biome)
 

--- a/internal/usercommands/break.go
+++ b/internal/usercommands/break.go
@@ -7,7 +7,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Break(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Break(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.Aggro != nil {
 		user.Character.Aggro = nil

--- a/internal/usercommands/broadcast.go
+++ b/internal/usercommands/broadcast.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Global chat room
-func Broadcast(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Broadcast(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Muted {
 		user.SendText(`You are <ansi fg="alert-5">MUTED</ansi>. You can only send <ansi fg="command">whisper</ansi>'s to Admins and Moderators.`)

--- a/internal/usercommands/bury.go
+++ b/internal/usercommands/bury.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Bury(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Bury(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/internal/usercommands/buy.go
+++ b/internal/usercommands/buy.go
@@ -17,10 +17,10 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Buy(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Buy(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
-		return List(rest, user, room)
+		return List(rest, user, room, flags)
 	}
 
 	targetMobInstanceId := 0

--- a/internal/usercommands/character.go
+++ b/internal/usercommands/character.go
@@ -20,7 +20,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Character(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Character(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if !room.IsCharacterRoom {
 		return false, fmt.Errorf(`not in a IsCharacterRoom`)
@@ -317,7 +317,7 @@ func Character(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 			tmpChar := user.Character
 			user.Character = &char
 
-			Status(``, user, room)
+			Status(``, user, room, flags)
 
 			user.Character = tmpChar
 

--- a/internal/usercommands/conditions.go
+++ b/internal/usercommands/conditions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Conditions(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Conditions(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	type buffInfo struct {
 		Name        string

--- a/internal/usercommands/consider.go
+++ b/internal/usercommands/consider.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Consider(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Consider(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/internal/usercommands/cooldowns.go
+++ b/internal/usercommands/cooldowns.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Cooldowns(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Cooldowns(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	cdTxt, _ := templates.Process("character/cooldowns", user.Character.GetAllCooldowns())
 	user.SendText(cdTxt)

--- a/internal/usercommands/default.go
+++ b/internal/usercommands/default.go
@@ -7,34 +7,34 @@ import (
 
 // Default is a special command that tries to contextually pick a default action for a room.
 // The failover is to "look"
-func Default(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Default(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// If there is a shop, "list"
 	if len(room.GetMobs(rooms.FindMerchant)) > 0 || len(room.GetPlayers(rooms.FindMerchant)) > 0 {
-		List(``, user, room)
+		List(``, user, room, flags)
 		return true, nil
 	}
 
 	// If there is a trainer, "train"
 	if len(room.SkillTraining) > 0 {
-		Train(``, user, room)
+		Train(``, user, room, flags)
 		return true, nil
 	}
 
 	// If a bank, "bank"
 	if room.IsBank {
-		Bank(``, user, room)
+		Bank(``, user, room, flags)
 		return true, nil
 	}
 
 	// If a storage location, "storage"
 	if room.IsStorage {
-		Storage(``, user, room)
+		Storage(``, user, room, flags)
 		return true, nil
 	}
 
 	// Default to "look"
-	Look(``, user, room)
+	Look(``, user, room, flags)
 
 	return true, nil
 }

--- a/internal/usercommands/drink.go
+++ b/internal/usercommands/drink.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Drink(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Drink(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/internal/usercommands/drop.go
+++ b/internal/usercommands/drop.go
@@ -15,7 +15,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Drop(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Drop(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
@@ -30,13 +30,13 @@ func Drop(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 		iCopies := []items.Item{}
 
 		if user.Character.Gold > 0 {
-			Drop(fmt.Sprintf("%d gold", user.Character.Gold), user, room)
+			Drop(fmt.Sprintf("%d gold", user.Character.Gold), user, room, flags)
 		}
 
 		iCopies = append(iCopies, user.Character.Items...)
 
 		for _, item := range iCopies {
-			Drop(item.Name(), user, room)
+			Drop(item.Name(), user, room, flags)
 		}
 
 		return true, nil

--- a/internal/usercommands/eat.go
+++ b/internal/usercommands/eat.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Eat(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Eat(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/internal/usercommands/emote.go
+++ b/internal/usercommands/emote.go
@@ -92,7 +92,7 @@ var (
 	}
 )
 
-func Emote(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Emote(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if len(rest) == 0 {
 		user.SendText("You emote.")

--- a/internal/usercommands/equip.go
+++ b/internal/usercommands/equip.go
@@ -10,10 +10,10 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Equip(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Equip(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "all" {
-		return Gearup(``, user, room)
+		return Gearup(``, user, room, flags)
 	}
 
 	// Check whether the user has an item in their inventory that matches

--- a/internal/usercommands/exits.go
+++ b/internal/usercommands/exits.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Exits(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Exits(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	details := rooms.GetDetails(room, user)
 

--- a/internal/usercommands/experience.go
+++ b/internal/usercommands/experience.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Experience(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Experience(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/internal/usercommands/flee.go
+++ b/internal/usercommands/flee.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Flee(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Flee(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.Aggro == nil || user.Character.Aggro.Type != characters.Flee {
 		user.SendText(`You attempt to flee...`)

--- a/internal/usercommands/follow.go
+++ b/internal/usercommands/follow.go
@@ -7,7 +7,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Follow(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Follow(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "" {
 		user.SendText("Follow whom?")

--- a/internal/usercommands/gearup.go
+++ b/internal/usercommands/gearup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Gearup(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Gearup(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	wornItems := map[items.ItemType]items.Item{}
 	wearNewItems := map[items.ItemType]items.Item{}

--- a/internal/usercommands/get.go
+++ b/internal/usercommands/get.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Get(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Get(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 
@@ -24,14 +24,14 @@ func Get(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 
 	if args[0] == "all" {
 		if room.Gold > 0 {
-			Get(`gold`, user, room)
+			Get(`gold`, user, room, flags)
 		}
 
 		if len(room.Items) > 0 {
 			iCopies := append([]items.Item{}, room.Items...)
 
 			for _, item := range iCopies {
-				Get(item.Name(), user, room)
+				Get(item.Name(), user, room, flags)
 			}
 		}
 

--- a/internal/usercommands/give.go
+++ b/internal/usercommands/give.go
@@ -15,7 +15,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Give(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Give(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	rest = util.StripPrepositions(rest)
 

--- a/internal/usercommands/go.go
+++ b/internal/usercommands/go.go
@@ -14,7 +14,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Go(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Go(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.Aggro != nil {
 		user.SendText("You can't do that! You are in combat!")
@@ -124,6 +124,12 @@ func Go(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 				}
 			}
 
+		}
+
+		if exitInfo.ExitMessage != `` && !flags.Has(CmdIsRequeue) {
+			user.SendText(exitInfo.ExitMessage)
+			user.CommandFlagged(rest, uint64(flags)|uint64(CmdIsRequeue), configs.GetConfig().SecondsToTurns(1))
+			return true, nil
 		}
 
 		// Load current room details
@@ -317,7 +323,7 @@ func Go(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
 			}
 
 			handled = true
-			Look(`secretly`, user, destRoom)
+			Look(``, user, destRoom, CmdSecretly) // Do a secret look.
 
 			scripting.TryRoomScriptEvent(`onEnter`, user.UserId, destRoom.RoomId)
 

--- a/internal/usercommands/help.go
+++ b/internal/usercommands/help.go
@@ -15,7 +15,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Help(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Help(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	var helpTxt string
 	var err error = nil

--- a/internal/usercommands/history.go
+++ b/internal/usercommands/history.go
@@ -7,7 +7,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func History(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func History(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	headers := []string{`Type` /*`Round`,*/, `Time`, `Log`}
 

--- a/internal/usercommands/inbox.go
+++ b/internal/usercommands/inbox.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Inbox(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Inbox(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == `clear` {
 		user.Inbox.Empty()

--- a/internal/usercommands/inventory.go
+++ b/internal/usercommands/inventory.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Inventory(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Inventory(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	itemNames := []string{}
 	itemNamesFormatted := []string{}

--- a/internal/usercommands/jobs.go
+++ b/internal/usercommands/jobs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Jobs(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Jobs(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	type JobDisplay struct {
 		Name       string

--- a/internal/usercommands/keyring.go
+++ b/internal/usercommands/keyring.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func KeyRing(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func KeyRing(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	headers := []string{`Type`, `Location`, `Where`, `Sequence`}
 	allFormatting := [][]string{}

--- a/internal/usercommands/killstats.go
+++ b/internal/usercommands/killstats.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Killstats(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Killstats(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	otherSuggestions := []string{}
 

--- a/internal/usercommands/leaderboard.go
+++ b/internal/usercommands/leaderboard.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Leaderboards(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Leaderboards(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if configs.GetConfig().LeaderboardSize == 0 {
 		user.SendText(`Leaderboards are disabled.`)

--- a/internal/usercommands/list.go
+++ b/internal/usercommands/list.go
@@ -18,7 +18,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func List(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func List(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	listedSomething := false
 

--- a/internal/usercommands/lock.go
+++ b/internal/usercommands/lock.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Lock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Lock(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/internal/usercommands/look.go
+++ b/internal/usercommands/look.go
@@ -14,13 +14,9 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Look(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Look(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
-	secretLook := false
-	if strings.HasPrefix(rest, "secretly") {
-		secretLook = true
-		rest = strings.TrimSpace(strings.TrimPrefix(rest, "secretly"))
-	}
+	secretLook := flags.Has(CmdSecretly)
 
 	visibility := room.GetVisibility()
 

--- a/internal/usercommands/macros.go
+++ b/internal/usercommands/macros.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Macros(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Macros(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if len(user.Macros) == 0 {
 		user.SendText("You have no macros set.")

--- a/internal/usercommands/motd.go
+++ b/internal/usercommands/motd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Motd(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Motd(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	user.SendText(string(configs.GetConfig().Motd))
 

--- a/internal/usercommands/noop.go
+++ b/internal/usercommands/noop.go
@@ -6,6 +6,6 @@ import (
 )
 
 // This is a no-op, does nothing
-func Noop(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Noop(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 	return true, nil
 }

--- a/internal/usercommands/offer.go
+++ b/internal/usercommands/offer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Offer(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Offer(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	item, found := user.Character.FindInBackpack(rest)
 	if !found {

--- a/internal/usercommands/online.go
+++ b/internal/usercommands/online.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Online(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Online(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	headers := []string{`Name`, `Level`, `Alignment`, `Profession`, `Online`, `Role`}
 

--- a/internal/usercommands/party.go
+++ b/internal/usercommands/party.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Party(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Party(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/internal/usercommands/password.go
+++ b/internal/usercommands/password.go
@@ -5,7 +5,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Password(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Password(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// Get if already exists, otherwise create new
 	cmdPrompt, _ := user.StartPrompt(`password`, rest)

--- a/internal/usercommands/pet.go
+++ b/internal/usercommands/pet.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Pet(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Pet(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/internal/usercommands/picklock.go
+++ b/internal/usercommands/picklock.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Picklock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Picklock(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	lockpickItm := items.Item{}
 	for _, itm := range user.Character.GetAllBackpackItems() {

--- a/internal/usercommands/print.go
+++ b/internal/usercommands/print.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Prints message to screen
-func Print(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Print(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	events.AddToQueue(events.Message{
 		UserId: user.UserId,
@@ -22,7 +22,7 @@ func Print(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 }
 
 // PrintLine (command `printline`) is just a simple measuring tool/ruler for layout purposes
-func PrintLine(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func PrintLine(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	sectionSize := 20
 

--- a/internal/usercommands/put.go
+++ b/internal/usercommands/put.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Put(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Put(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/internal/usercommands/pvp.go
+++ b/internal/usercommands/pvp.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Pvp(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Pvp(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	setting := configs.GetConfig().PVP
 

--- a/internal/usercommands/quests.go
+++ b/internal/usercommands/quests.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Quests(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Quests(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	type QuestRecord struct {
 		Id          int

--- a/internal/usercommands/quit.go
+++ b/internal/usercommands/quit.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Quit(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Quit(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.Aggro != nil {
 		user.SendText("You're too busy to quit right now!")

--- a/internal/usercommands/read.go
+++ b/internal/usercommands/read.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Read(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Read(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 

--- a/internal/usercommands/remove.go
+++ b/internal/usercommands/remove.go
@@ -9,11 +9,11 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Remove(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Remove(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if rest == "all" {
 		for _, item := range user.Character.Equipment.GetAllItems() {
-			Remove(item.Name(), user, room)
+			Remove(item.Name(), user, room, flags)
 		}
 		return true, nil
 	}

--- a/internal/usercommands/save.go
+++ b/internal/usercommands/save.go
@@ -5,7 +5,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Save(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Save(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	user.SendText("Saving...")
 	users.SaveUser(*user)

--- a/internal/usercommands/say.go
+++ b/internal/usercommands/say.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Say(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Say(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Muted {
 		user.SendText(`You are <ansi fg="alert-5">MUTED</ansi>. You can only send <ansi fg="command">whisper</ansi>'s to Admins and Moderators.`)

--- a/internal/usercommands/sell.go
+++ b/internal/usercommands/sell.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Sell(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Sell(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	item, found := user.Character.FindInBackpack(rest)
 

--- a/internal/usercommands/set.go
+++ b/internal/usercommands/set.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Set(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Set(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/internal/usercommands/share.go
+++ b/internal/usercommands/share.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Share(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Share(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	party := parties.Get(user.UserId)
 	if party == nil {

--- a/internal/usercommands/shoot.go
+++ b/internal/usercommands/shoot.go
@@ -14,7 +14,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Shoot(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Shoot(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.Equipment.Weapon.GetSpec().Subtype != items.Shooting {
 		user.SendText(`You don't have a shooting weapon.`)

--- a/internal/usercommands/shout.go
+++ b/internal/usercommands/shout.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Shout(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Shout(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Muted {
 		user.SendText(`You are <ansi fg="alert-5">MUTED</ansi>. You can only send <ansi fg="command">whisper</ansi>'s to Admins and Moderators.`)

--- a/internal/usercommands/show.go
+++ b/internal/usercommands/show.go
@@ -13,7 +13,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Show(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Show(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	rest = util.StripPrepositions(rest)
 

--- a/internal/usercommands/skill.brawling.disarm.go
+++ b/internal/usercommands/skill.brawling.disarm.go
@@ -15,7 +15,7 @@ import (
 Brawling Skill
 Level 4 - Attempt to disarm an opponent.
 */
-func Disarm(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Disarm(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 

--- a/internal/usercommands/skill.brawling.recover.go
+++ b/internal/usercommands/skill.brawling.recover.go
@@ -13,7 +13,7 @@ import (
 Brawling Skill
 Level 1 - Enter a state of rest where health is recovered more quickly
 */
-func Recover(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Recover(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 

--- a/internal/usercommands/skill.brawling.tackle.go
+++ b/internal/usercommands/skill.brawling.tackle.go
@@ -15,7 +15,7 @@ import (
 Brawling Skill
 Level 3 - Attempt to tackle an opponent, making them miss a round.
 */
-func Tackle(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Tackle(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 

--- a/internal/usercommands/skill.brawling.throw.go
+++ b/internal/usercommands/skill.brawling.throw.go
@@ -22,7 +22,7 @@ import (
 Brawling Skill
 Level 2 - You can throw objects at NPCs or other rooms.
 */
-func Throw(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Throw(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Brawling)
 	handled := false

--- a/internal/usercommands/skill.cast.go
+++ b/internal/usercommands/skill.cast.go
@@ -23,7 +23,7 @@ Level 2 - Become proficient in a spell at 125% rate
 Level 3 - Become proficient in a spell at 175% rate
 Level 4 - Become proficient in a spell at 250% rate
 */
-func Cast(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Cast(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Cast)
 

--- a/internal/usercommands/skill.dualwield.go
+++ b/internal/usercommands/skill.dualwield.go
@@ -15,7 +15,7 @@ Level 2 - Occasionaly you will attack with both weapons in one round.
 Level 3 - You will always attack with both weapons when Dual wielding.
 Level 4 - Dual wielding incurs fewer penalties
 */
-func DualWield(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func DualWield(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.DualWield)
 
@@ -24,6 +24,6 @@ func DualWield(rest string, user *users.UserRecord, room *rooms.Room) (bool, err
 		return true, errors.New(`you haven't learned how to dual wield`)
 	}
 
-	return Help(`dual-wield`, user, room)
+	return Help(`dual-wield`, user, room, flags)
 
 }

--- a/internal/usercommands/skill.enchant.go
+++ b/internal/usercommands/skill.enchant.go
@@ -13,12 +13,12 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Uncurse(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
-	return Enchant("uncurse "+rest, user, room)
+func Uncurse(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
+	return Enchant("uncurse "+rest, user, room, flags)
 }
 
-func Unenchant(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
-	return Enchant("remove "+rest, user, room)
+func Unenchant(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
+	return Enchant("remove "+rest, user, room, flags)
 }
 
 /*
@@ -28,7 +28,7 @@ Level 2 - Enchant equipment with a defensive bonus.
 Level 3 - Add a stat bonus to a weapon or equipment in addition to the above.
 Level 4 - Remove the enchantment or curse from any object.
 */
-func Enchant(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Enchant(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Enchant)
 

--- a/internal/usercommands/skill.inspect.go
+++ b/internal/usercommands/skill.inspect.go
@@ -18,7 +18,7 @@ Level 2 - Reveals weapon damage or uses an item has left.
 Level 3 - Reveals any stat modifiers an item has.
 Level 4 - Reveals special magical properties like elemental effects.
 */
-func Inspect(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Inspect(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.GetSkillLevel(skills.Inspect) == 0 {
 		user.SendText("You don't know how to inspect.")

--- a/internal/usercommands/skill.map.go
+++ b/internal/usercommands/skill.map.go
@@ -21,7 +21,7 @@ Level 2 - Map a 9x7 area
 Level 3 - Map a 13x9 area
 Level 4 - Map a 17x9 area, and enables the "wide" version.
 */
-func Map(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Map(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Map)
 

--- a/internal/usercommands/skill.peep.go
+++ b/internal/usercommands/skill.peep.go
@@ -21,7 +21,7 @@ Level 2 - Reveals detailed stats of a player or mob.
 Level 3 - Reveals detailed stats of the player or mob, plus equipment and items
 Level 4 - eveals detailed stats of the player or mob, plus equipment and items, and tells you the % chance of dropping items.
 */
-func Peep(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Peep(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Peep)
 

--- a/internal/usercommands/skill.portal.go
+++ b/internal/usercommands/skill.portal.go
@@ -22,7 +22,7 @@ Level 2 - Teleport back to the root of the area you are in
 Level 3 - Set a new destination for your portal teleportation
 Level 4 - Create a physical portal that you can share with players, or return through.
 */
-func Portal(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Portal(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.RoomId == int(configs.GetConfig().DeathRecoveryRoom) {
 		return false, errors.New(`portal command ignored in death recovery`)
@@ -30,7 +30,7 @@ func Portal(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 
 	// This is a hack because using "portal" to enter an existing portal is very common
 	if rest == `` {
-		if handled, err := Go(`portal`, user, room); handled {
+		if handled, err := Go(`portal`, user, room, flags); handled {
 			return handled, err
 		}
 	}

--- a/internal/usercommands/skill.protection.aid.go
+++ b/internal/usercommands/skill.protection.aid.go
@@ -17,7 +17,7 @@ Protection Skill
 Level 1 - Aid (revive) a player
 Level 3 - Aid (revive) a player, even during combat
 */
-func Aid(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Aid(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Protection)
 

--- a/internal/usercommands/skill.protection.pray.go
+++ b/internal/usercommands/skill.protection.pray.go
@@ -16,7 +16,7 @@ import (
 Protection Skill
 Level 4 - Pray to gods for a blessing
 */
-func Pray(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Pray(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Protection)
 

--- a/internal/usercommands/skill.protection.rank.go
+++ b/internal/usercommands/skill.protection.rank.go
@@ -13,7 +13,7 @@ import (
 Protection Skill
 Level 2 - Front/Backrank
 */
-func Rank(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Rank(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Protection)
 

--- a/internal/usercommands/skill.scribe.go
+++ b/internal/usercommands/skill.scribe.go
@@ -18,7 +18,7 @@ Level 2 - Scribe to a sign
 Level 3 - Scribe a hidden rune
 Level 4 - TODO
 */
-func Scribe(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Scribe(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Scribe)
 

--- a/internal/usercommands/skill.search.go
+++ b/internal/usercommands/skill.search.go
@@ -26,7 +26,7 @@ Level 4 - You are always aware of hidden players/mobs in the area
 (Lvl 3) <ansi fg="skill">search</ansi> Finds special/unknown "things of interest" in the area.
 (Lvl 4) <ansi fg="skill">search</ansi> Doubles your chance of success when searching.
 */
-func Search(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Search(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Search)
 

--- a/internal/usercommands/skill.skulduggery.backstab.go
+++ b/internal/usercommands/skill.skulduggery.backstab.go
@@ -17,7 +17,7 @@ import (
 SkullDuggery Skill
 Level 2 - Backstab
 */
-func Backstab(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Backstab(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 

--- a/internal/usercommands/skill.skulduggery.bump.go
+++ b/internal/usercommands/skill.skulduggery.bump.go
@@ -16,7 +16,7 @@ import (
 SkullDuggery Skill
 Level 3 - Backstab
 */
-func Bump(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Bump(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 

--- a/internal/usercommands/skill.skulduggery.pickpocket.go
+++ b/internal/usercommands/skill.skulduggery.pickpocket.go
@@ -17,7 +17,7 @@ import (
 SkullDuggery Skill
 Level 4 - Pickpocket
 */
-func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Pickpocket(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 

--- a/internal/usercommands/skill.skulduggery.sneak.go
+++ b/internal/usercommands/skill.skulduggery.sneak.go
@@ -12,7 +12,7 @@ import (
 SkullDuggery Skill
 Level 1 - Sneak
 */
-func Sneak(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Sneak(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Skulduggery)
 

--- a/internal/usercommands/skill.tame.go
+++ b/internal/usercommands/skill.tame.go
@@ -23,7 +23,7 @@ Level 2 - Tame up to 3 creatures
 Level 3 - Tame up to 4 creatures
 Level 4 - Tame up to 5 creatures
 */
-func Tame(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Tame(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Tame)
 	if skillLevel == 0 {

--- a/internal/usercommands/skill.track.go
+++ b/internal/usercommands/skill.track.go
@@ -30,7 +30,7 @@ Level 2 - Display all players and mobs to recently walk through here
 Level 3 - Shows exit information for all tracked players or mobs
 Level 4 - Specify a mob or username and every room you enter will tell you what exit they took.
 */
-func Track(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Track(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	skillLevel := user.Character.GetSkillLevel(skills.Track)
 

--- a/internal/usercommands/skills.go
+++ b/internal/usercommands/skills.go
@@ -14,7 +14,7 @@ type SkillsOptions struct {
 	SkillCooldowns map[string]int
 }
 
-func Skills(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Skills(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	allSkills := user.Character.GetSkills()
 	allCooldowns := map[string]int{}

--- a/internal/usercommands/spells.go
+++ b/internal/usercommands/spells.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Spells(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Spells(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	headers := []string{`SpellId`, `Name`, `Description`, `Target`, `MPs`, `Wait`, `Casts`, `% Chance`}
 

--- a/internal/usercommands/start.go
+++ b/internal/usercommands/start.go
@@ -19,7 +19,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Start(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Start(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if user.Character.RoomId != -1 {
 		return false, errors.New(`only allowed in the void`)
@@ -70,7 +70,7 @@ func Start(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 			}
 
 			question.RejectResponse()
-			return Help(helpCmd+` `+helpRest, user, room)
+			return Help(helpCmd+` `+helpRest, user, room, flags)
 		}
 
 		raceNameSelection := question.Response
@@ -166,7 +166,7 @@ func Start(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) 
 
 		if question.Response == `no` {
 			user.ClearPrompt()
-			return Start(rest, user, room)
+			return Start(rest, user, room, flags)
 		}
 
 		if err := user.SetCharacterName(usernameSelected); err != nil {

--- a/internal/usercommands/stash.go
+++ b/internal/usercommands/stash.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Stash(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Stash(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/internal/usercommands/status.go
+++ b/internal/usercommands/status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Status(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Status(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	//possibleStatuses := []string{`strength`, `speed`, `smarts`, `vitality`, `mysticism`, `perception`}
 
@@ -108,7 +108,7 @@ func Status(rest string, user *users.UserRecord, room *rooms.Room) (bool, error)
 	tplTxt, _ := templates.Process("character/status", user)
 	user.SendText(tplTxt)
 
-	Inventory(``, user, room)
+	Inventory(``, user, room, flags)
 
 	return true, nil
 }

--- a/internal/usercommands/storage.go
+++ b/internal/usercommands/storage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Storage(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Storage(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if !room.IsStorage {
 
@@ -73,7 +73,7 @@ func Storage(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 		if itemName == `all` {
 
 			for _, itm := range user.Character.GetAllBackpackItems() {
-				Storage(fmt.Sprintf(`add !%d`, itm.ItemId), user, room)
+				Storage(fmt.Sprintf(`add !%d`, itm.ItemId), user, room, flags)
 
 				spaceLeft--
 				if spaceLeft < 0 {
@@ -104,7 +104,7 @@ func Storage(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 		if itemName == `all` {
 
 			for _, itm := range user.ItemStorage.GetItems() {
-				Storage(fmt.Sprintf(`remove !%d`, itm.ItemId), user, room)
+				Storage(fmt.Sprintf(`remove !%d`, itm.ItemId), user, room, flags)
 			}
 
 			return true, nil

--- a/internal/usercommands/suicide.go
+++ b/internal/usercommands/suicide.go
@@ -17,7 +17,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Suicide(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	config := configs.GetConfig()
 	currentRound := util.GetRoundCount()
@@ -103,10 +103,10 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 
 			// Unequip everything
 			for _, itm := range user.Character.GetAllWornItems() {
-				Remove(itm.Name(), user, room)
+				Remove(itm.Name(), user, room, flags)
 			}
 			// drop all items / gold
-			Drop("all", user, room)
+			Drop("all", user, room, flags)
 
 			rooms.MoveToRoom(user.UserId, -1)
 
@@ -127,9 +127,9 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 			for _, itm := range user.Character.GetAllWornItems() {
 				if util.Rand(100) < chanceInt {
 
-					Remove(itm.Name(), user, room)
+					Remove(itm.Name(), user, room, flags)
 
-					Drop(itm.Name(), user, room)
+					Drop(itm.Name(), user, room, flags)
 
 				}
 			}
@@ -137,11 +137,11 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 
 		if user.Character.Gold > 0 {
 			user.EventLog.Add(`death`, fmt.Sprintf(`Dropped <ansi fg="gold">%d gold</ansi> on death`, user.Character.Gold))
-			Drop(fmt.Sprintf(`%d gold`, user.Character.Gold), user, room)
+			Drop(fmt.Sprintf(`%d gold`, user.Character.Gold), user, room, flags)
 		}
 
 		if config.OnDeathAlwaysDropBackpack {
-			Drop("all", user, room)
+			Drop("all", user, room, flags)
 
 			user.EventLog.Add(`death`, `Dropped <ansi fg="alert-3">everthing in your backpack</ansi> on death`)
 
@@ -149,7 +149,7 @@ func Suicide(rest string, user *users.UserRecord, room *rooms.Room) (bool, error
 			chanceInt := int(config.OnDeathEquipmentDropChance * 100)
 			for _, itm := range user.Character.GetAllBackpackItems() {
 				if util.Rand(100) < chanceInt {
-					Drop(itm.Name(), user, room)
+					Drop(itm.Name(), user, room, flags)
 					user.EventLog.Add(`death`, fmt.Sprintf(`Dropped your <ansi fg="itemname">%s</ansi> on death`, itm.Name()))
 				}
 			}

--- a/internal/usercommands/time.go
+++ b/internal/usercommands/time.go
@@ -8,7 +8,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Time(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Time(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	gd := gametime.GetDate()
 

--- a/internal/usercommands/train.go
+++ b/internal/usercommands/train.go
@@ -23,7 +23,7 @@ type TrainingOptions struct {
 	Options        []TrainingOption
 }
 
-func Train(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Train(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	if len(room.SkillTraining) == 0 {
 		user.SendText(`You must find a trainer to perform training.`)

--- a/internal/usercommands/trash.go
+++ b/internal/usercommands/trash.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Trash(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Trash(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	// Check whether the user has an item in their inventory that matches
 	matchItem, found := user.Character.FindInBackpack(rest)

--- a/internal/usercommands/unlock.go
+++ b/internal/usercommands/unlock.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Unlock(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Unlock(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(strings.ToLower(rest))
 

--- a/internal/usercommands/use.go
+++ b/internal/usercommands/use.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Use(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Use(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	containerName := room.FindContainerByName(rest)
 	if containerName != `` {

--- a/internal/usercommands/whisper.go
+++ b/internal/usercommands/whisper.go
@@ -9,7 +9,7 @@ import (
 	"github.com/volte6/gomud/internal/util"
 )
 
-func Whisper(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Whisper(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	args := util.SplitButRespectQuotes(rest)
 

--- a/internal/usercommands/who.go
+++ b/internal/usercommands/who.go
@@ -6,7 +6,7 @@ import (
 	"github.com/volte6/gomud/internal/users"
 )
 
-func Who(rest string, user *users.UserRecord, room *rooms.Room) (bool, error) {
+func Who(rest string, user *users.UserRecord, room *rooms.Room, flags UserCommandFlag) (bool, error) {
 
 	details := rooms.GetDetails(room, user)
 

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -200,6 +200,22 @@ func (u *UserRecord) Command(inputTxt string, waitTurns ...int) {
 
 }
 
+func (u *UserRecord) CommandFlagged(inputTxt string, flagData uint64, waitTurns ...int) {
+
+	wt := 0
+	if len(waitTurns) > 0 {
+		wt = waitTurns[0]
+	}
+
+	events.AddToQueue(events.Input{
+		UserId:    u.UserId,
+		InputText: inputTxt,
+		WaitTurns: wt,
+		Flags:     flagData,
+	})
+
+}
+
 func (u *UserRecord) AddBuff(buffId int) {
 
 	events.AddToQueue(events.Buff{
@@ -620,7 +636,6 @@ func (u *UserRecord) GetPrompt() *prompt.Prompt {
 }
 
 func (u *UserRecord) ClearPrompt() {
-
 	u.activePrompt = nil
 }
 

--- a/world.go
+++ b/world.go
@@ -761,7 +761,7 @@ loop:
 	}
 }
 
-func (w *World) processInput(userId int, inputText string) {
+func (w *World) processInput(userId int, inputText string, flags usercommands.UserCommandFlag) {
 
 	user := users.GetByUserId(userId)
 	if user == nil { // Something went wrong. User not found.
@@ -837,7 +837,7 @@ func (w *World) processInput(userId int, inputText string) {
 				command = inputText
 			}
 
-			handled, err = usercommands.TryCommand(command, remains, userId)
+			handled, err = usercommands.TryCommand(command, remains, userId, flags)
 			if err != nil {
 				slog.Error("user-TryCommand", "command", command, "remains", remains, "error", err.Error())
 			}
@@ -1356,7 +1356,7 @@ func (w *World) TurnTick() {
 		}
 
 		if input.WaitTurns < 0 { // -1 and below, process immediately and don't count towards limit
-			w.processInput(input.UserId, input.InputText)
+			w.processInput(input.UserId, input.InputText, usercommands.UserCommandFlag(input.Flags))
 			continue
 		}
 
@@ -1366,7 +1366,7 @@ func (w *World) TurnTick() {
 		}
 
 		if input.WaitTurns == 0 { // 0 means process immediately but wait another turn before processing another from this user
-			w.processInput(input.UserId, input.InputText)
+			w.processInput(input.UserId, input.InputText, usercommands.UserCommandFlag(input.Flags))
 			alreadyProcessed[input.UserId] = struct{}{}
 		} else {
 			input.WaitTurns--

--- a/world.roundtick.go
+++ b/world.roundtick.go
@@ -546,7 +546,7 @@ func (w *World) handlePlayerCombat() (affectedPlayerIds []int, affectedMobInstan
 
 				newRoom := rooms.LoadRoom(exitRoomId)
 
-				usercommands.Look(`secretly`, user, newRoom)
+				usercommands.Look(``, user, newRoom, usercommands.CmdSecretly)
 
 				scripting.TryRoomScriptEvent(`onEnter`, user.UserId, exitRoomId)
 


### PR DESCRIPTION
# Changes
* Added room exit messages to exit definitions
* Added prompt for customizing exit message in `room edit exits` command
* Exit messages display and then wait 1 second before continuing through the exit.
* Fixing `zone edit` prompt around music to allow for no music, and provides relative path if needed.
