### PR TITLE
Misc. Web Customizations

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -23,6 +23,10 @@
 #   overwrite your changes.
 #
 ################################################################################
+# - MudName - 
+#   Display name of the MUD.
+#   This will be used a few places by default (such as the web pages).
+MudName: "GoMud"
 # - Version - 
 #   Latest semantic version of the datafiles (MAJOR.MINOR.PATCH)
 #   Do not change this value, it will be handled by the server when updated

--- a/_datafiles/html/public/_header.html
+++ b/_datafiles/html/public/_header.html
@@ -4,14 +4,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>GoMud: The Open-source MUD server, written in Go</title>
+  <title>Welcome to {{ mudname }}</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" />
   <link rel="stylesheet" href="/static/public/css/gomud.css">
 </head>
 <body>
   <header>
     <div>
-      <a class="gomud-btn" href="/">GoMud</a>
+      <a class="gomud-btn" href="/">{{ mudname }}</a>
     </div>
     <div class="nav-toggle" onclick="toggleMenu()">
       <div></div>
@@ -22,7 +22,7 @@
 
   <nav>
     <div class="nav-container">
-      <a href="/">Home</a>
+      <a href="/">Go Home</a>
       <a href="/online">Who's Online</a>
       <a href="/webclient">Web Client</a>
       <a href="/viewconfig">See Configuration</a>

--- a/_datafiles/html/public/webclient.html
+++ b/_datafiles/html/public/webclient.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>GoMud Web Terminal</title>
+    <title>{{ mudname }} Web Terminal</title>
     <style>
         * {
             box-sizing: border-box;
@@ -190,7 +190,7 @@
     </div>
 
     <!-- CONNECT BUTTON FLOATED IN CENTER -->
-    <button id="connect-button">Connect</button>
+    <button id="connect-button">Connect to {{ .MudName }}</button>
 
     <div id="input-area">
         <input type="text" id="command-input" placeholder="Enter command...">
@@ -298,8 +298,8 @@
                 socket.close();
                 return;
             }
-            debugLog("Connecting to: " + 'ws://'+location.host +':80/ws');
-            socket = new WebSocket('ws://'+location.host +':80/ws');
+            debugLog("Connecting to: " + 'ws://'+location.host +':{{ .WebPort }}/ws');
+            socket = new WebSocket('ws://'+location.host +':{{ .WebPort }}/ws');
 
             socket.onopen = function() {
                 term.writeln("Connected to the server!");

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -23,7 +23,8 @@ const (
 )
 
 type Config struct {
-	Version              ConfigString `yaml:"Version"` // Cuurrent version of all datafiles
+	MudName              ConfigString `yaml:"MudName"` // Name of the MUD
+	Version              ConfigString `yaml:"Version"` // Current version of all datafiles
 	MaxCPUCores          ConfigInt    `yaml:"MaxCPUCores"`
 	FolderDataFiles      ConfigString `yaml:"FolderDataFiles"`
 	FolderHtmlFiles      ConfigString `yaml:"FolderHtmlFiles"`

--- a/internal/web/home.go
+++ b/internal/web/home.go
@@ -21,5 +21,12 @@ func serveHome(w http.ResponseWriter, r *http.Request) {
 
 func serveClient(w http.ResponseWriter, r *http.Request) {
 	// read contents of webclient.html and print it out
-	http.ServeFile(w, r, configs.GetConfig().FolderHtmlFiles.String()+"/public/webclient.html")
+
+	tmpl, err := template.New("webclient.html").Funcs(funcMap).ParseFiles(configs.GetConfig().FolderHtmlFiles.String() + "/public/webclient.html")
+	if err != nil {
+		mudlog.Error("HTML ERROR", "error", err)
+	}
+
+	tmpl.Execute(w, configs.GetConfig())
+
 }

--- a/internal/web/template_func.go
+++ b/internal/web/template_func.go
@@ -5,6 +5,8 @@ import (
 	"html"
 	"strings"
 	"text/template"
+
+	"github.com/volte6/gomud/internal/configs"
 )
 
 var (
@@ -96,6 +98,9 @@ var (
 		},
 		"lowercase": func(str string) string {
 			return strings.ToLower(str)
+		},
+		"mudname": func() string {
+			return string(configs.GetConfig().MudName)
 		},
 	}
 )

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -32,6 +32,7 @@ func Listen(webPort int, wg *sync.WaitGroup, webSocketHandler func(*websocket.Co
 
 	// HTTP Server
 	httpServer = &http.Server{Addr: fmt.Sprintf(`:%d`, webPort)}
+
 	// Routing
 	// Basic homepage
 	http.HandleFunc("/", serveHome)


### PR DESCRIPTION
# Changes

* Added `MudName` config - should be name of mud.
* Injecting `MudName` various web places (webclient connect button, page titles, page header nav)
* Using defined webport in config for webclient (was hard coded)

Example:

![Screenshot 2025-03-01 at 2 14 23 PM](https://github.com/user-attachments/assets/e40579c4-4fac-41bf-a911-1715c222fed0)
![Screenshot 2025-03-01 at 2 14 05 PM](https://github.com/user-attachments/assets/bee2a736-1030-4042-af68-a087c6324e02)
