### PR TITLE
Config Override Bad Data Fix

### DIFF
--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -316,7 +316,7 @@ func (c *Config) SetOverrides(overrides map[string]any) error {
 		}
 
 		if !structFieldValue.CanSet() {
-			mudlog.Error("SetOverrides()", "error", fmt.Sprint("Cannot set %s field value", name))
+			mudlog.Error("SetOverrides()", "error", fmt.Sprintf("Cannot set %s field value", name))
 			continue
 		}
 
@@ -327,7 +327,7 @@ func (c *Config) SetOverrides(overrides map[string]any) error {
 		fieldVal := val.FieldByName(name)
 
 		if !fieldVal.IsValid() {
-			mudlog.Error("SetOverrides()", "error", fmt.Sprint("no such field: %s in obj", name))
+			mudlog.Error("SetOverrides()", "error", fmt.Sprintf("no such field: %s in obj", name))
 			continue
 		}
 
@@ -341,7 +341,7 @@ func (c *Config) SetOverrides(overrides map[string]any) error {
 		method := fieldValPtr.MethodByName("Set")
 
 		if !method.IsValid() {
-			mudlog.Error("SetOverrides()", "error", fmt.Sprint("Set method missing: %s", name))
+			mudlog.Error("SetOverrides()", "error", fmt.Sprintf("Set method missing: %s", name))
 			continue
 		}
 		// Prepare arguments and call the method as before

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -311,11 +311,13 @@ func (c *Config) SetOverrides(overrides map[string]any) error {
 		structFieldValue := structValue.FieldByName(name)
 
 		if !structFieldValue.IsValid() {
-			return fmt.Errorf("No such field: %s in obj", name)
+			mudlog.Error("SetOverrides()", "error", fmt.Sprintf("No such field: %s in obj", name))
+			continue
 		}
 
 		if !structFieldValue.CanSet() {
-			return fmt.Errorf("Cannot set %s field value", name)
+			mudlog.Error("SetOverrides()", "error", fmt.Sprint("Cannot set %s field value", name))
+			continue
 		}
 
 		// Get the reflect.Value of instance
@@ -325,19 +327,22 @@ func (c *Config) SetOverrides(overrides map[string]any) error {
 		fieldVal := val.FieldByName(name)
 
 		if !fieldVal.IsValid() {
-			return fmt.Errorf("no such field: %s in obj", name)
+			mudlog.Error("SetOverrides()", "error", fmt.Sprint("no such field: %s in obj", name))
+			continue
 		}
 
 		// If fieldVal is struct and Set has a pointer receiver, you need to get the address of fieldVal
 		if !fieldVal.CanAddr() {
-			return fmt.Errorf("field is not addressable")
+			mudlog.Error("SetOverrides()", "error", "field is not addressable")
+			continue
 		}
 
 		fieldValPtr := fieldVal.Addr() // Get a pointer to the field
 		method := fieldValPtr.MethodByName("Set")
 
 		if !method.IsValid() {
-			return fmt.Errorf("Set method missing")
+			mudlog.Error("SetOverrides()", "error", fmt.Sprint("Set method missing: %s", name))
+			continue
 		}
 		// Prepare arguments and call the method as before
 		args := []reflect.Value{reflect.ValueOf(fmt.Sprintf(`%v`, value))}


### PR DESCRIPTION
# Description

When the config overrides file is loaded, if a key is provided that is unrecognized, it sends an error and aborts loading the overrides file.
This is a problem, since it then fails over to default values (Web Port etc).

# Changes

* Changed overrides loading to log an error instead of returning an error, and just skips the single bad keyname.