### PR TITLE
Fix invalid charactor buffId cause nil pointer panic

### DIFF
--- a/internal/buffs/buffs.go
+++ b/internal/buffs/buffs.go
@@ -1,5 +1,9 @@
 package buffs
 
+import (
+	"github.com/volte6/gomud/internal/mudlog"
+)
+
 const (
 	TriggersLeftExpired   = 0 // When it hits this number it will be pruned ASAP
 	TriggersLeftUnlimited = 1000000000
@@ -59,6 +63,10 @@ func (bs *Buffs) Validate(forceRebuild ...bool) {
 		for idx, b := range bs.List {
 			bs.buffIds[b.BuffId] = idx
 			bSpec := GetBuffSpec(b.BuffId)
+			if bSpec == nil {
+				mudlog.Warn("buffs.Validate()", "buffId", b.BuffId, "error", "invalid character buffId")
+				continue
+			}
 			for _, flag := range bSpec.Flags {
 				if _, ok := bs.buffFlags[flag]; !ok {
 					bs.buffFlags[flag] = []int{}


### PR DESCRIPTION
Invalid value for field `buffId` in the user file `_datafiles/world/empty/users/1.yaml`

error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9ee7cd]

goroutine 40 [running]:
github.com/volte6/gomud/internal/buffs.(*Buffs).Validate(0xc000258228, {0x0, 0x0, 0x0})
	/home/lostsnow/projects/github/mud/GoMud/internal/buffs/buffs.go:62 +0x2ed
github.com/volte6/gomud/internal/characters.(*Character).Validate(0xc000258008, {0xc00015a20e, 0x1, 0x1})
	/home/lostsnow/projects/github/mud/GoMud/internal/characters/character.go:1479 +0x365
github.com/volte6/gomud/internal/users.LoadUser({0xc000504260, 0x5}, {0x0, 0x0, 0x0})
	/home/lostsnow/projects/github/mud/GoMud/internal/users/users.go:380 +0x6ce
github.com/volte6/gomud/internal/inputhandlers.LoginInputHandler(0xc000502000, 0xc0002ef3e0)
	/home/lostsnow/projects/github/mud/GoMud/internal/inputhandlers/login.go:116 +0x121e
github.com/volte6/gomud/internal/connections.(*ConnectionDetails).HandleInput(0xc00036c000, 0xc000502000, 0xc0002ef3e0)
	/home/lostsnow/projects/github/mud/GoMud/internal/connections/connectiondetails.go:146 +0x2cf
main.handleTelnetConnection(0xc00036c000, 0x1964f20)
	/home/lostsnow/projects/github/mud/GoMud/main.go:425 +0x11b7

```