### PR TITLE
Login/Signup prompt overhaul

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -465,6 +465,11 @@ Validation:
   #   Min/Max size of passwords allowed.
   PasswordSizeMin: 4
   PasswordSizeMax: 16
+  # - EmailOnJoin -
+  #   Whether to ask for email addresses on signup.
+  #   Can be "required", "optional", "none"
+  #   Default: "optional"
+  EmailOnJoin: optional
   # - NameRejectRegex -
   #   A special pattern to reject usernames that match it.
   #   (This is a regular expression, you must understand how to create them)

--- a/_datafiles/localize/en.yaml
+++ b/_datafiles/localize/en.yaml
@@ -20,8 +20,6 @@ RoomId:
 '%d user online':
 
 Login.CreateUser: |-
-  <ansi fg="alert-5">CAUTION:</ansi> This will be your login username, NOT your character name!
-  If you choose this for your login name, you CANNOT use it as a character name.
   Would you like to create a new user/login named <ansi fg="magenta">{{ .Username }}</ansi>?
 
 Inbox.UnreadMessageWithCheck: >-

--- a/_datafiles/localize/zh.yaml
+++ b/_datafiles/localize/zh.yaml
@@ -16,8 +16,6 @@ RoomId: '房间ID'
 '%d user online': '在线用户 %d 人'
 
 Login.CreateUser: |-
-  <ansi fg="alert-5">注意:</ansi> 这将是您的登录用户名, 而不是您的角色名!
-  如果您选择此名称作为登录名, 则不能将其用作角色名.
   您想创建一个登录名为 <ansi fg="magenta">{{ .Username }}</ansi> 的新用户吗?
 
 Inbox.UnreadMessageWithCheck: >-

--- a/_datafiles/world/default/templates/login/email-new.prompt.template
+++ b/_datafiles/world/default/templates/login/email-new.prompt.template
@@ -1,0 +1,1 @@
+<ansi fg="39">Email Address</ansi><ansi fg="black-bold">{{ if .emailIsOptional }} (optional){{ end }}: </ansi>

--- a/_datafiles/world/default/templates/login/password-new-verify.prompt.template
+++ b/_datafiles/world/default/templates/login/password-new-verify.prompt.template
@@ -1,0 +1,1 @@
+<ansi fg="39"><ansi fg="123">Repeat</ansi> your password</ansi><ansi fg="black-bold">: </ansi>

--- a/_datafiles/world/default/templates/login/password-new.prompt.template
+++ b/_datafiles/world/default/templates/login/password-new.prompt.template
@@ -1,0 +1,1 @@
+<ansi fg="39">Choose your password</ansi><ansi fg="black-bold">: </ansi>

--- a/_datafiles/world/default/templates/login/username-new.prompt.template
+++ b/_datafiles/world/default/templates/login/username-new.prompt.template
@@ -1,0 +1,5 @@
+
+<ansi fg="alert-5">CAUTION:</ansi> This will be your login username, NOT your character name!
+Whatever you use as your login name CANNOT be used as a character name.
+
+<ansi fg="39">Choose your username</ansi><ansi fg="black-bold">: </ansi>

--- a/_datafiles/world/default/templates/login/username.prompt.template
+++ b/_datafiles/world/default/templates/login/username.prompt.template
@@ -1,1 +1,1 @@
-<ansi fg="39">{{ t "Login.username" }}</ansi><ansi fg="black-bold">: </ansi>
+<ansi fg="39">{{ t "Login.username" }}</ansi><ansi fg="black-bold"> (or "new"): </ansi>

--- a/_datafiles/world/empty/templates/login/email-new.prompt.template
+++ b/_datafiles/world/empty/templates/login/email-new.prompt.template
@@ -1,0 +1,1 @@
+<ansi fg="39">Email Address</ansi><ansi fg="black-bold">{{ if .emailIsOptional }} (optional){{ end }}: </ansi>

--- a/_datafiles/world/empty/templates/login/password-new-verify.prompt.template
+++ b/_datafiles/world/empty/templates/login/password-new-verify.prompt.template
@@ -1,0 +1,1 @@
+<ansi fg="39"><ansi fg="123">Repeat</ansi> your password</ansi><ansi fg="black-bold">: </ansi>

--- a/_datafiles/world/empty/templates/login/password-new.prompt.template
+++ b/_datafiles/world/empty/templates/login/password-new.prompt.template
@@ -1,0 +1,1 @@
+<ansi fg="39">Choose your password</ansi><ansi fg="black-bold">: </ansi>

--- a/_datafiles/world/empty/templates/login/username-new.prompt.template
+++ b/_datafiles/world/empty/templates/login/username-new.prompt.template
@@ -1,0 +1,5 @@
+
+<ansi fg="alert-5">CAUTION:</ansi> This will be your login username, NOT your character name!
+Whatever you use as your login name CANNOT be used as a character name.
+
+<ansi fg="39">Choose your username</ansi><ansi fg="black-bold">: </ansi>

--- a/_datafiles/world/empty/templates/login/username.prompt.template
+++ b/_datafiles/world/empty/templates/login/username.prompt.template
@@ -1,1 +1,1 @@
-<ansi fg="39">{{ t "Login.username" }}</ansi><ansi fg="black-bold">: </ansi>
+<ansi fg="39">{{ t "Login.username" }}</ansi><ansi fg="black-bold"> (or "new"): </ansi>

--- a/internal/configs/config.validation.go
+++ b/internal/configs/config.validation.go
@@ -12,6 +12,7 @@ type Validation struct {
 	PasswordSizeMax  ConfigInt         `yaml:"PasswordSizeMax"`
 	NameRejectRegex  ConfigString      `yaml:"NameRejectRegex"`
 	NameRejectReason ConfigString      `yaml:"NameRejectReason"`
+	EmailOnJoin      ConfigString      `yaml:"EmailOnJoin"`
 	BannedNames      ConfigSliceString `yaml:"BannedNames"` // List of names that are not allowed to be used
 }
 
@@ -38,6 +39,10 @@ func (v *Validation) Validate() {
 	}
 	if v.PasswordSizeMax < v.PasswordSizeMin {
 		v.PasswordSizeMax = v.PasswordSizeMin
+	}
+
+	if v.EmailOnJoin != `required` && v.EmailOnJoin != `none` {
+		v.EmailOnJoin = `optional`
 	}
 
 }

--- a/internal/events/eventtypes.go
+++ b/internal/events/eventtypes.go
@@ -148,6 +148,16 @@ type NewTurn struct {
 func (n NewTurn) Type() string { return `NewTurn` }
 
 // Gained or lost an item
+type EquipmentChange struct {
+	UserId        int
+	MobInstanceId int
+	ItemsWorn     []items.Item
+	ItemsRemoved  []items.Item
+}
+
+func (i EquipmentChange) Type() string { return `EquipmentChange` }
+
+// Gained or lost an item
 type ItemOwnership struct {
 	UserId        int
 	MobInstanceId int

--- a/internal/inputhandlers/login_prompt_handler.go
+++ b/internal/inputhandlers/login_prompt_handler.go
@@ -1,0 +1,387 @@
+package inputhandlers
+
+import (
+	"errors"
+	"fmt"
+	"net/mail"
+	"strings"
+
+	"github.com/volte6/gomud/internal/configs"
+	"github.com/volte6/gomud/internal/connections"
+	"github.com/volte6/gomud/internal/events"
+	"github.com/volte6/gomud/internal/mudlog"
+	"github.com/volte6/gomud/internal/templates"
+	"github.com/volte6/gomud/internal/term"
+	"github.com/volte6/gomud/internal/users"
+)
+
+var (
+	ErrInputRequired        = errors.New(`input required`)
+	ErrInvalidResponse      = errors.New(`invalid response`)
+	ErrPasswordsDidNotMatch = errors.New(`your passwords did not match`)
+)
+
+const promptHandlerStateKey = "PromptHandlerState" // Keep unexported if only used within this package
+
+// CompletionFunc is called when all steps are successfully completed.
+// It receives the accumulated results and the shared state.
+// It should return true if the overall process succeeded and the handler can be removed,
+// false otherwise (e.g., login failed, disconnect).
+type CompletionFunc func(results map[string]string, sharedState map[string]any, clientInput *connections.ClientInput) bool
+
+// PromptHandlerState holds the current state of the multi-step prompt process for a connection.
+type PromptHandlerState struct {
+	Steps            []*PromptStep
+	CurrentStepIndex int
+	Results          map[string]string
+	OnComplete       CompletionFunc
+	maskTemplate     string // Cached mask character template
+}
+
+// ValidationFunc defines a function type for validating user input for a step.
+// It takes the raw input and the accumulated results so far.
+// It returns the cleaned/validated value (or an empty string) and an error if validation fails.
+type ValidationFunc func(input string, results map[string]string) (string, error)
+
+// ConditionFunc defines a function type to determine if a step should be executed.
+// It takes the accumulated results so far.
+type ConditionFunc func(results map[string]string) bool
+
+// DataFunc generates dynamic data for a prompt step based on prior results.
+type DataFunc func(results map[string]string) map[string]any
+
+// PromptStep defines a single step in a multi-step prompt process.
+type PromptStep struct {
+	ID             string         // Unique identifier for this step's result
+	PromptTemplate string         // Template name for the prompt message
+	GetDataFunc    DataFunc       // Function to generate template data dynamically (optional)
+	MaskInput      bool           // Should the input be masked?
+	MaskTemplate   string         // Template for the mask character (optional)
+	Validator      ValidationFunc // Function to validate the input, if returns false, repeat prompt
+	Condition      ConditionFunc  // Do this step unless Condition Function returns false
+	FailureCount   int            // Can be added if needed, managed within PromptHandlerState
+}
+
+// AlwaysRun is a default ConditionFunc that always returns true.
+func AlwaysRun(_ map[string]string) bool {
+	return true
+}
+
+// DefaultValidator is a basic validator that accepts any non-empty input.
+func DefaultValidator(input string, _ map[string]string) (string, error) {
+	if len(input) == 0 {
+		return "", ErrInputRequired // Example error message key
+	}
+	return input, nil
+}
+
+func ValidateNewEntry(input string, _ map[string]string) (string, error) {
+	if strings.ToLower(input) == `new` {
+		return `new`, nil
+	}
+
+	validation := configs.GetValidationConfig()
+
+	if len(input) < int(validation.NameSizeMin) {
+		return "", errors.New("try again.")
+	}
+
+	return input, nil
+}
+
+// Specific Validators
+func ValidateUsername(input string, _ map[string]string) (string, error) {
+	if err := users.ValidateName(input); err != nil {
+		return "", err
+	}
+
+	return input, nil
+}
+
+func ValidatePassword(input string, _ map[string]string) (string, error) {
+	if err := users.ValidatePassword(input); err != nil {
+		return "", err
+	}
+	return input, nil
+}
+
+func ValidatePassword2(input string, results map[string]string) (string, error) {
+	if results[`password-new`] != input {
+		return "", ErrPasswordsDidNotMatch
+	}
+	return input, nil
+}
+
+func ValidateEmail(input string, results map[string]string) (string, error) {
+
+	if input == `` {
+
+		if configs.GetValidationConfig().EmailOnJoin == `required` {
+			return ``, ErrInputRequired
+		}
+
+		return ``, nil
+	}
+
+	if _, err := mail.ParseAddress(input); err != nil {
+		return ``, err
+	}
+
+	return input, nil
+}
+
+func ValidateYesNo(input string, _ map[string]string) (string, error) {
+
+	cleanInput := strings.ToLower(input)
+	if len(cleanInput) == 0 {
+		return "n", nil // Default to 'no' if empty input
+	}
+
+	cleanInput = cleanInput[0:1]
+
+	if cleanInput == `y` {
+		return "y", nil
+	}
+
+	if cleanInput == `n` {
+		return "n", nil
+	}
+	// Provide more specific feedback
+	return "", ErrInvalidResponse
+}
+
+// CreatePromptHandler creates a generic input handler for multi-step prompts.
+func CreatePromptHandler(steps []*PromptStep, onComplete CompletionFunc) connections.InputHandler {
+
+	// Return the actual handler function closure
+	return func(clientInput *connections.ClientInput, sharedState map[string]any) bool {
+
+		var state *PromptHandlerState
+		stateVal, ok := sharedState[promptHandlerStateKey]
+
+		if !ok {
+
+			state = &PromptHandlerState{
+				Steps:            steps,
+				CurrentStepIndex: -1, // Will be incremented by advanceAndSendPrompt
+				Results:          make(map[string]string),
+				OnComplete:       onComplete,
+			}
+			sharedState[promptHandlerStateKey] = state
+
+			// Find and send the first applicable prompt
+			if advanceAndSendPrompt(state, clientInput) {
+				// Edge case: No steps were applicable, sequence completes immediately
+				mudlog.Warn("Prompt sequence completed immediately (no applicable steps)", "connectionId", clientInput.ConnectionId)
+				success := state.OnComplete(state.Results, sharedState, clientInput)
+				delete(sharedState, promptHandlerStateKey) // Clean up state
+				return success
+			}
+			return false // Waiting for input for the first prompt
+		}
+
+		state = stateVal.(*PromptHandlerState) // We assume it's the correct type
+
+		// Check if index is valid (should always be, unless state is corrupted)
+		if state.CurrentStepIndex < 0 || state.CurrentStepIndex >= len(state.Steps) {
+
+			mudlog.Error("Invalid prompt state: CurrentStepIndex out of bounds", "index", state.CurrentStepIndex, "numSteps", len(state.Steps), "connectionId", clientInput.ConnectionId)
+			// Clean up corrupted state
+			delete(sharedState, promptHandlerStateKey)
+			// Disconnect likely safest
+			connections.Remove(clientInput.ConnectionId)
+			// Indicate failure/disconnect
+			return false
+		}
+
+		currentStep := state.Steps[state.CurrentStepIndex]
+
+		// Input Buffering and Echo
+		if !clientInput.EnterPressed {
+
+			if clientInput.BSPressed && len(clientInput.Buffer) > 0 {
+
+				// Handle Backspace
+				clientInput.Buffer = clientInput.Buffer[:len(clientInput.Buffer)-1]
+				//connections.SendTo([]byte{term.ASCII_BACKSPACE, term.ASCII_SPACE, term.ASCII_BACKSPACE}, clientInput.ConnectionId)
+
+			} else if !clientInput.BSPressed && len(clientInput.DataIn) > 0 && clientInput.DataIn[0] >= 32 {
+
+				// Handle printable characters
+				//clientInput.Buffer = append(clientInput.Buffer, clientInput.DataIn...)
+
+				// Echo or Mask
+				if currentStep.MaskInput {
+
+					// Cache the mask template string if needed
+					if state.maskTemplate == "" && currentStep.MaskTemplate != "" {
+
+						if maskStr, err := templates.Process(currentStep.MaskTemplate, nil, templates.AnsiTagsPreParse); err != nil {
+							mudlog.Error("Mask template error", "template", currentStep.MaskTemplate, "error", err)
+							state.maskTemplate = "*" // Fallback mask
+						} else {
+							state.maskTemplate = templates.AnsiParse(maskStr)
+						}
+
+					} else if state.maskTemplate == "" {
+						state.maskTemplate = "*" // Default fallback if no template specified
+					}
+
+					// Send mask character(s)
+					for i := 0; i < len(clientInput.DataIn); i++ {
+						connections.SendTo([]byte(state.maskTemplate), clientInput.ConnectionId)
+					}
+
+				} else {
+					// Echo input directly
+					connections.SendTo(clientInput.DataIn, clientInput.ConnectionId)
+				}
+
+			}
+
+			// Non-Enter input processed, wait for more
+			return false
+		}
+
+		if connections.IsWebsocket(clientInput.ConnectionId) {
+			connections.SendTo(clientInput.Buffer, clientInput.ConnectionId) // Echo newline
+		}
+
+		// Enter Pressed: Process Input
+		connections.SendTo(term.CRLF, clientInput.ConnectionId) // Echo newline
+		submittedInput := strings.TrimSpace(string(clientInput.Buffer))
+		clientInput.Buffer = clientInput.Buffer[:0] // Clear buffer for next input
+		state.maskTemplate = ""                     // Clear cached mask template
+
+		// Validation
+
+		validatedValue, err := currentStep.Validator(submittedInput, state.Results)
+		if err != nil {
+
+			/////////////////////////////////////////////////////////////////
+			// Validation failed, send error message and re-prompt
+			/////////////////////////////////////////////////////////////////
+
+			errMsg := err.Error() // Use the error message directly (could be from language.T)
+			connections.SendTo([]byte(errMsg), clientInput.ConnectionId)
+			connections.SendTo(term.CRLF, clientInput.ConnectionId)
+
+			if currentStep.ID == `password-new-verify` {
+				state.CurrentStepIndex -= 1
+				currentStep = state.Steps[state.CurrentStepIndex]
+			}
+
+			// Increment failure counter in case we want to disconnect the user
+			currentStep.FailureCount++
+			if currentStep.FailureCount >= 3 {
+				connections.SendTo([]byte(term.CRLFStr+`Too many mistakes.`+term.CRLFStr+term.CRLFStr), clientInput.ConnectionId)
+				connections.Remove(clientInput.ConnectionId)
+				state.CurrentStepIndex += 99
+				return false
+			}
+
+			// Resend current prompt
+			sendPrompt(currentStep, clientInput, state.Results)
+
+			// Waiting for input again
+			return false
+		}
+
+		/////////////////////////////////////////////////////////////////
+		// Validation success
+		/////////////////////////////////////////////////////////////////
+
+		state.Results[currentStep.ID] = validatedValue
+
+		mudlog.Debug("Prompt Step Success", "step", currentStep.ID, "value", validatedValue, "connectionId", clientInput.ConnectionId)
+
+		// Advance to Next Step or Complete
+		if advanceAndSendPrompt(state, clientInput) {
+
+			// Sequence complete
+			mudlog.Debug("Prompt sequence completed", "connectionId", clientInput.ConnectionId)
+
+			// Call the final completion function
+			success := state.OnComplete(state.Results, sharedState, clientInput)
+
+			// Clean up state
+			delete(sharedState, promptHandlerStateKey)
+
+			// Return completion result (true = handler done, false = e.g., login failed/disconnect)
+			return success
+		}
+
+		// Moved to the next prompt, waiting for input
+		return false
+	}
+}
+
+// sendPrompt sends the prompt for the given step to the client.
+func sendPrompt(step *PromptStep, clientInput *connections.ClientInput, results map[string]string) {
+
+	templateName := step.PromptTemplate
+	var templateData map[string]any
+
+	// Generate dynamic data if GetDataFunc is provided
+	if step.GetDataFunc != nil {
+		templateData = step.GetDataFunc(results)
+	} else {
+		// Fallback to empty map if no dynamic data needed/provided
+		templateData = make(map[string]any)
+	}
+
+	// Process the template
+	promptTxt, err := templates.Process(templateName, templateData, templates.AnsiTagsPreParse)
+	if err != nil {
+		mudlog.Error("Prompt template error", "template", templateName, "error", err)
+		promptTxt = fmt.Sprintf("Error generating prompt '%s'", step.ID) // Fallback
+	}
+
+	parsedPrompt := templates.AnsiParse(promptTxt)
+	connections.SendTo([]byte(parsedPrompt), clientInput.ConnectionId)
+
+	// Handle websocket masking command
+	if connections.IsWebsocket(clientInput.ConnectionId) {
+		maskCmd := "TEXTMASK:false"
+		if step.MaskInput {
+			maskCmd = "TEXTMASK:true"
+		}
+		events.AddToQueue(events.WebClientCommand{
+			ConnectionId: clientInput.ConnectionId,
+			Text:         maskCmd,
+		})
+	}
+}
+
+// advanceAndSendPrompt finds the next valid step and sends its prompt.
+// Returns true if the sequence is complete, false otherwise.
+func advanceAndSendPrompt(state *PromptHandlerState, clientInput *connections.ClientInput) bool {
+
+	state.CurrentStepIndex++
+
+	for state.CurrentStepIndex < len(state.Steps) {
+
+		step := state.Steps[state.CurrentStepIndex]
+
+		// Determine condition (default to AlwaysRun)
+		condition := step.Condition
+		if condition == nil {
+			condition = AlwaysRun
+		}
+
+		// Check condition against current results
+		if condition(state.Results) {
+			// Condition met, send this prompt
+			sendPrompt(step, clientInput, state.Results)
+			return false // Not complete, waiting for input for this step
+		}
+
+		// Condition not met, skip this step
+		mudlog.Debug("Skipping prompt step", "step", step.ID, "connectionId", clientInput.ConnectionId)
+
+		state.CurrentStepIndex++
+	}
+
+	// No more steps left
+	return true // Sequence is complete
+}

--- a/internal/mobcommands/equip.go
+++ b/internal/mobcommands/equip.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/volte6/gomud/internal/buffs"
+	"github.com/volte6/gomud/internal/events"
 	"github.com/volte6/gomud/internal/items"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/rooms"
@@ -89,6 +90,12 @@ func Equip(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 				}
 
 				mob.Character.Validate()
+
+				events.AddToQueue(events.EquipmentChange{
+					MobInstanceId: mob.InstanceId,
+					ItemsWorn:     []items.Item{matchItem},
+					ItemsRemoved:  oldItems,
+				})
 			}
 		}
 

--- a/internal/mobcommands/remove.go
+++ b/internal/mobcommands/remove.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/volte6/gomud/internal/buffs"
+	"github.com/volte6/gomud/internal/events"
+	"github.com/volte6/gomud/internal/items"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/rooms"
 )
@@ -16,9 +18,17 @@ func Remove(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 	}
 
 	if rest == "all" {
+		removedItems := []items.Item{}
 		for _, item := range mob.Character.Equipment.GetAllItems() {
 			Remove(item.Name(), mob, room)
+			removedItems = append(removedItems, item)
 		}
+
+		events.AddToQueue(events.EquipmentChange{
+			MobInstanceId: mob.InstanceId,
+			ItemsRemoved:  removedItems,
+		})
+
 		return true, nil
 	}
 
@@ -39,6 +49,11 @@ func Remove(rest string, mob *mobs.Mob, room *rooms.Room) (bool, error) {
 		}
 
 		mob.Character.Validate()
+
+		events.AddToQueue(events.EquipmentChange{
+			MobInstanceId: mob.InstanceId,
+			ItemsRemoved:  []items.Item{matchItem},
+		})
 
 	}
 

--- a/internal/usercommands/equip.go
+++ b/internal/usercommands/equip.go
@@ -90,6 +90,13 @@ func Equip(rest string, user *users.UserRecord, room *rooms.Room, flags events.E
 			}
 
 			user.Character.Validate(true)
+
+			events.AddToQueue(events.EquipmentChange{
+				UserId:       user.UserId,
+				ItemsWorn:    []items.Item{matchItem},
+				ItemsRemoved: oldItems,
+			})
+
 		} else {
 			if len(failureReason) == 1 {
 				failureReason = fmt.Sprintf(`You can't figure out how to equip the <ansi fg="item">%s</ansi>.`, matchItem.DisplayName())

--- a/internal/users/userrecord.go
+++ b/internal/users/userrecord.go
@@ -40,6 +40,8 @@ type UserRecord struct {
 	Inbox          Inbox                 `yaml:"inbox,omitempty"`
 	Muted          bool                  `yaml:"muted,omitempty"`        // Cannot SEND custom communications to anyone but admin/mods
 	Deafened       bool                  `yaml:"deafened,omitempty"`     // Cannot HEAR custom communications from anyone but admin/mods
+	ScreenReader   bool                  `yaml:"screenreader,omitempty"` // Are they using a screen reader? (We should remove excess symbols)
+	EmailAddress   string                `yaml:"emailaddress,omitempty"` // Email address (if provided)
 	TipsComplete   map[string]bool       `yaml:"tipscomplete,omitempty"` // Tips the user has followed/completed so they can be quiet
 	EventLog       UserLog               `yaml:"-"`                      // Do not retain in user file (for now)
 	LastMusic      string                `yaml:"-"`                      // Keeps track of the last music that was played

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -293,20 +293,6 @@ func CreateUser(u *UserRecord) error {
 		return errors.New("that username is not allowed: " + err.Error())
 	}
 
-	if bannedPattern, ok := configs.GetConfig().IsBannedName(u.Username); ok {
-		return errors.New(`that username matched the prohibited name pattern: "` + bannedPattern + `"`)
-	}
-
-	for _, name := range mobs.GetAllMobNames() {
-		if strings.EqualFold(name, u.Username) {
-			return errors.New("that username is in use")
-		}
-	}
-
-	if Exists(u.Username) {
-		return errors.New("that username is in use")
-	}
-
 	u.UserId = GetUniqueUserId()
 	u.Role = RoleUser
 
@@ -423,6 +409,31 @@ func ValidateName(name string) error {
 		if !regexp.MustCompile(validation.NameRejectRegex.String()).MatchString(name) {
 			return errors.New(validation.NameRejectReason.String())
 		}
+	}
+
+	if bannedPattern, ok := configs.GetConfig().IsBannedName(name); ok {
+		return errors.New(`that username matched the prohibited name pattern: "` + bannedPattern + `"`)
+	}
+
+	for _, mobName := range mobs.GetAllMobNames() {
+		if strings.EqualFold(mobName, name) {
+			return errors.New("that username is in use")
+		}
+	}
+
+	if Exists(name) {
+		return errors.New("that username is in use")
+	}
+
+	return nil
+}
+
+func ValidatePassword(pw string) error {
+
+	validation := configs.GetValidationConfig()
+
+	if len(pw) < int(validation.PasswordSizeMin) || len(pw) > int(validation.PasswordSizeMax) {
+		return fmt.Errorf("password must be between %d and %d characters long", validation.PasswordSizeMin, validation.PasswordSizeMax)
 	}
 
 	return nil


### PR DESCRIPTION
# Changes
* New system of prompts.
  * Creating a new account required typing "new" at login (per instructino)
  * Now collects email address (configurable to be off/optional/required)
  * Now asks if using a screen reader
* Added `EquipmentChange{}` event.
  * No handlers for this event yet, but it's firing
  * Includes any items put on or taken off (sometimes both at once when it's a gear swap)
* Some additional protection around accidentally sending telnet commands to websockets.