### PR TITLE
Fix some template pad functions with wide charactors

### DIFF
--- a/internal/templates/templatesfunctions.go
+++ b/internal/templates/templatesfunctions.go
@@ -112,18 +112,9 @@ var (
 		"pct":          pct,
 		"numberFormat": numberFormat,
 		"mod":          func(a, b int) int { return a % b },
-		"stringor": func(a string, b string, padding ...int) string {
-			str := a
-			if str == "" {
-				str = b
-			}
-			if len(padding) > 0 {
-				str = fmt.Sprintf("%-"+strconv.Itoa(padding[0])+"s", str)
-			}
-			return str
-		},
-		"splitstring": SplitStringNL,
-		"ansiparse":   TplAnsiParse,
+		"stringor":     stringOr,
+		"splitstring":  SplitStringNL,
+		"ansiparse":    TplAnsiParse,
 		"buffname": func(buffId int) string {
 			buffSpec := buffs.GetBuffSpec(buffId)
 			if buffSpec == nil {
@@ -245,10 +236,12 @@ func padLeft(totalWidth int, stringArgs ...string) string {
 		}
 	}
 
-	if len(stringIn) >= totalWidth {
+	stringInWidth := runewidth.StringWidth(stringIn)
+
+	if stringInWidth >= totalWidth {
 		return stringIn
 	}
-	paddingLength := totalWidth - len(stringIn)
+	paddingLength := totalWidth - stringInWidth
 	if paddingLength < 1 {
 		return stringIn
 	}
@@ -272,10 +265,12 @@ func padRight(totalWidth int, stringArgs ...string) string {
 		}
 	}
 
-	if len(stringIn) >= totalWidth {
+	stringInWidth := runewidth.StringWidth(stringIn)
+
+	if stringInWidth >= totalWidth {
 		return stringIn
 	}
-	paddingLength := totalWidth - len(stringIn)
+	paddingLength := totalWidth - stringInWidth
 	if paddingLength < 1 {
 		return stringIn
 	}
@@ -286,6 +281,10 @@ func padRightX(input, padding string, length int) string {
 
 	padLen := runewidth.StringWidth(padding)
 	inputLen := runewidth.StringWidth(input)
+
+	if length < inputLen {
+		length = inputLen
+	}
 
 	// Calculate how many times the padding string should be repeated
 	paddingRepeats := int(math.Ceil((float64(length) - float64(inputLen)) / float64(padLen)))
@@ -309,7 +308,7 @@ func padRightX(input, padding string, length int) string {
 // Usage:
 //
 //	{{ pad 10 }}
-//		OUTPUT: "		  "
+//		OUTPUT: "          "
 //	{{ pad 11 "hello" "-" }}
 //		OUTPUT: "---hello---"
 func pad(totalWidth int, stringArgs ...string) string {
@@ -323,10 +322,12 @@ func pad(totalWidth int, stringArgs ...string) string {
 		}
 	}
 
-	if len(stringIn) >= totalWidth {
+	stringInWidth := runewidth.StringWidth(stringIn)
+
+	if stringInWidth >= totalWidth {
 		return stringIn
 	}
-	paddingLength := totalWidth - len(stringIn)
+	paddingLength := totalWidth - stringInWidth
 	leftPad := paddingLength >> 1
 	if leftPad < 1 {
 		return stringIn
@@ -363,6 +364,17 @@ func numberFormat(num int) string {
 
 func TplAnsiParse(input string) string {
 	return AnsiParse(input)
+}
+
+func stringOr(a string, b string, padding ...int) string {
+	str := a
+	if str == "" {
+		str = b
+	}
+	if len(padding) > 0 {
+		str = padRight(padding[0], str)
+	}
+	return str
 }
 
 // Splits a string by adding line breaks at the end of each line

--- a/internal/templates/templatesfunctions.go
+++ b/internal/templates/templatesfunctions.go
@@ -17,7 +17,6 @@ import (
 	"github.com/volte6/gomud/internal/language"
 	"github.com/volte6/gomud/internal/mobs"
 	"github.com/volte6/gomud/internal/skills"
-	"github.com/volte6/gomud/internal/term"
 	"github.com/volte6/gomud/internal/users"
 	"github.com/volte6/gomud/internal/util"
 )
@@ -113,7 +112,7 @@ var (
 		"numberFormat": numberFormat,
 		"mod":          func(a, b int) int { return a % b },
 		"stringor":     stringOr,
-		"splitstring":  SplitStringNL,
+		"splitstring":  util.SplitStringNL,
 		"ansiparse":    TplAnsiParse,
 		"buffname": func(buffId int) string {
 			buffSpec := buffs.GetBuffSpec(buffId)
@@ -375,46 +374,6 @@ func stringOr(a string, b string, padding ...int) string {
 		str = padRight(padding[0], str)
 	}
 	return str
-}
-
-// Splits a string by adding line breaks at the end of each line
-func SplitStringNL(input string, lineWidth int, nlPrefix ...string) string {
-
-	output := strings.Builder{}
-
-	words := strings.Fields(input) // Split the input into words
-
-	linePrefix := ""
-	if len(nlPrefix) > 0 {
-		linePrefix = nlPrefix[0]
-	}
-
-	currentLine := ""
-	for _, word := range words {
-		if len(currentLine)+len(word)+1 <= lineWidth { // +1 for the space
-			if currentLine == "" {
-				currentLine = word
-			} else {
-				currentLine += " " + word
-			}
-		} else {
-			if linePrefix != "" && output.Len() > 0 {
-				output.WriteString(linePrefix)
-			}
-			output.WriteString(currentLine)
-			output.WriteString(term.CRLFStr)
-			currentLine = word
-		}
-	}
-
-	if currentLine != "" {
-		if linePrefix != "" && output.Len() > 0 {
-			output.WriteString(linePrefix)
-		}
-		output.WriteString(currentLine)
-	}
-
-	return output.String()
 }
 
 func formatDuration(seconds int) string {

--- a/internal/templates/templatesfunctions_test.go
+++ b/internal/templates/templatesfunctions_test.go
@@ -1,0 +1,205 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPad(t *testing.T) {
+	type args struct {
+		width     int
+		stringIn  string
+		padString string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"Pad empty string with space", args{10, "", ""}, "          "},
+		{"Pad empty string with minus", args{10, "", "-"}, "----------"},
+		{"Pad with space", args{10, "test", ""}, "   test   "},
+		{"Pad with space 2", args{10, "hello", ""}, "  hello   "},
+		{"Pad with minus", args{10, "test", "-"}, "---test---"},
+		{"Pad with space and zero width", args{0, "test", ""}, "test"},
+		{"Pad with space and smaller width", args{3, "test", ""}, "test"},
+		{"Pad with space and same width", args{4, "test", ""}, "test"},
+		{"Pad wild charactors with space", args{10, "宽字符", ""}, "  宽字符  "},
+		{"Pad wild charactors with space 2", args{10, "宽字符A", ""}, " 宽字符A  "},
+		{"Pad wild charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
+		{"Pad wild charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
+		{"Pad wild charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			if tt.args.stringIn == "" && tt.args.padString == "" {
+				got = pad(tt.args.width)
+			} else if tt.args.padString == "" {
+				got = pad(tt.args.width, tt.args.stringIn)
+			} else {
+				got = pad(tt.args.width, tt.args.stringIn, tt.args.padString)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPadLeft(t *testing.T) {
+	type args struct {
+		width     int
+		stringIn  string
+		padString string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"PadLeft empty string with space", args{10, "", ""}, "          "},
+		{"PadLeft empty string with minus", args{10, "", "-"}, "----------"},
+		{"PadLeft with space", args{10, "test", ""}, "      test"},
+		{"PadLeft with space 2", args{10, "hello", ""}, "     hello"},
+		{"PadLeft with minus", args{10, "test", "-"}, "------test"},
+		{"PadLeft with space and zero width", args{0, "test", ""}, "test"},
+		{"PadLeft with space and smaller width", args{3, "test", ""}, "test"},
+		{"PadLeft with space and same width", args{4, "test", ""}, "test"},
+		{"PadLeft wild charactors with space", args{10, "宽字符", ""}, "    宽字符"},
+		{"PadLeft wild charactors with space 2", args{10, "宽字符A", ""}, "   宽字符A"},
+		{"PadLeft wild charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
+		{"PadLeft wild charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
+		{"PadLeft wild charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			if tt.args.stringIn == "" && tt.args.padString == "" {
+				got = padLeft(tt.args.width)
+			} else if tt.args.padString == "" {
+				got = padLeft(tt.args.width, tt.args.stringIn)
+			} else {
+				got = padLeft(tt.args.width, tt.args.stringIn, tt.args.padString)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	type args struct {
+		width     int
+		stringIn  string
+		padString string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"PadRight empty string with space", args{10, "", ""}, "          "},
+		{"PadRight empty string with minus", args{10, "", "-"}, "----------"},
+		{"PadRight with space", args{10, "test", ""}, "test      "},
+		{"PadRight with space 2", args{10, "hello", ""}, "hello     "},
+		{"PadRight with minus", args{10, "test", "-"}, "test------"},
+		{"PadRight with space and zero width", args{0, "test", ""}, "test"},
+		{"PadRight with space and smaller width", args{3, "test", ""}, "test"},
+		{"PadRight with space and same width", args{4, "test", ""}, "test"},
+		{"PadRight wild charactors with space", args{10, "宽字符", ""}, "宽字符    "},
+		{"PadRight wild charactors with space 2", args{10, "宽字符A", ""}, "宽字符A   "},
+		{"PadRight wild charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
+		{"PadRight wild charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
+		{"PadRight wild charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			if tt.args.stringIn == "" && tt.args.padString == "" {
+				got = padRight(tt.args.width)
+			} else if tt.args.padString == "" {
+				got = padRight(tt.args.width, tt.args.stringIn)
+			} else {
+				got = padRight(tt.args.width, tt.args.stringIn, tt.args.padString)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPadRightX(t *testing.T) {
+	type args struct {
+		width     int
+		stringIn  string
+		padString string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"PadRightX empty string with space", args{10, "", " "}, "          "},
+		{"PadRightX empty string with minus", args{10, "", "-"}, "----------"},
+		{"PadRightX empty string with minus and plus", args{10, "", "-+"}, "-+-+-+-+-+"},
+		{"PadRightX empty string with minus plus and dot", args{10, "", "-+."}, "-+.-+.-+.-"},
+		{"PadRightX with space", args{10, "test", " "}, "test      "},
+		{"PadRightX with space 2", args{10, "hello", " "}, "hello     "},
+		{"PadRightX with minus", args{10, "test", "-"}, "test------"},
+		{"PadRightX with space and zero width", args{0, "test", " "}, "test"},
+		{"PadRightX with space and smaller width", args{3, "test", " "}, "test"},
+		{"PadRightX with space and same width", args{4, "test", " "}, "test"},
+		{"PadRightX wild charactors with space", args{10, "宽字符", " "}, "宽字符    "},
+		{"PadRightX wild charactors with space 2", args{10, "宽字符A", " "}, "宽字符A   "},
+		{"PadRightX wild charactors with space and zero width", args{0, "宽字符", " "}, "宽字符"},
+		{"PadRightX wild charactors with space and smaller width", args{5, "宽字符", " "}, "宽字符"},
+		{"PadRightX wild charactors with space and same width", args{6, "宽字符", " "}, "宽字符"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := padRightX(tt.args.stringIn, tt.args.padString, tt.args.width)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStringOr(t *testing.T) {
+	type args struct {
+		stringA string
+		stringB string
+		padding []int
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"StringOr", args{"a", "b", []int{10}}, "a         "},
+		{"StringOr empty string a and b", args{"", "", []int{10}}, "          "},
+		{"StringOr empty string a", args{"", "b", []int{10}}, "b         "},
+		{"StringOr empty string b", args{"a", "", []int{10}}, "a         "},
+		{"StringOr without padding", args{"a", "b", nil}, "a"},
+		{"StringOr with zero width", args{"test", "b", []int{0}}, "test"},
+		{"StringOr with smaller width", args{"test", "b", []int{3}}, "test"},
+		{"StringOr with same width", args{"test", "b", []int{4}}, "test"},
+		{"StringOr wild charactors", args{"宽字符", "", []int{10}}, "宽字符    "},
+		{"StringOr wild charactors 2", args{"宽字符A", "", []int{10}}, "宽字符A   "},
+		{"StringOr wild charactors with zero width", args{"宽字符", "", []int{0}}, "宽字符"},
+		{"StringOr wild charactors with smaller width", args{"宽字符", "", []int{5}}, "宽字符"},
+		{"StringOr wild charactors with same width", args{"宽字符", "", []int{6}}, "宽字符"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringOr(tt.args.stringA, tt.args.stringB, tt.args.padding...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/templates/templatesfunctions_test.go
+++ b/internal/templates/templatesfunctions_test.go
@@ -26,11 +26,11 @@ func TestPad(t *testing.T) {
 		{"Pad with space and zero width", args{0, "test", ""}, "test"},
 		{"Pad with space and smaller width", args{3, "test", ""}, "test"},
 		{"Pad with space and same width", args{4, "test", ""}, "test"},
-		{"Pad wild charactors with space", args{10, "宽字符", ""}, "  宽字符  "},
-		{"Pad wild charactors with space 2", args{10, "宽字符A", ""}, " 宽字符A  "},
-		{"Pad wild charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
-		{"Pad wild charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
-		{"Pad wild charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
+		{"Pad wide charactors with space", args{10, "宽字符", ""}, "  宽字符  "},
+		{"Pad wide charactors with space 2", args{10, "宽字符A", ""}, " 宽字符A  "},
+		{"Pad wide charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
+		{"Pad wide charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
+		{"Pad wide charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
 	}
 
 	for _, tt := range tests {
@@ -68,11 +68,11 @@ func TestPadLeft(t *testing.T) {
 		{"PadLeft with space and zero width", args{0, "test", ""}, "test"},
 		{"PadLeft with space and smaller width", args{3, "test", ""}, "test"},
 		{"PadLeft with space and same width", args{4, "test", ""}, "test"},
-		{"PadLeft wild charactors with space", args{10, "宽字符", ""}, "    宽字符"},
-		{"PadLeft wild charactors with space 2", args{10, "宽字符A", ""}, "   宽字符A"},
-		{"PadLeft wild charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
-		{"PadLeft wild charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
-		{"PadLeft wild charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
+		{"PadLeft wide charactors with space", args{10, "宽字符", ""}, "    宽字符"},
+		{"PadLeft wide charactors with space 2", args{10, "宽字符A", ""}, "   宽字符A"},
+		{"PadLeft wide charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
+		{"PadLeft wide charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
+		{"PadLeft wide charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
 	}
 
 	for _, tt := range tests {
@@ -110,11 +110,11 @@ func TestPadRight(t *testing.T) {
 		{"PadRight with space and zero width", args{0, "test", ""}, "test"},
 		{"PadRight with space and smaller width", args{3, "test", ""}, "test"},
 		{"PadRight with space and same width", args{4, "test", ""}, "test"},
-		{"PadRight wild charactors with space", args{10, "宽字符", ""}, "宽字符    "},
-		{"PadRight wild charactors with space 2", args{10, "宽字符A", ""}, "宽字符A   "},
-		{"PadRight wild charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
-		{"PadRight wild charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
-		{"PadRight wild charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
+		{"PadRight wide charactors with space", args{10, "宽字符", ""}, "宽字符    "},
+		{"PadRight wide charactors with space 2", args{10, "宽字符A", ""}, "宽字符A   "},
+		{"PadRight wide charactors with space and zero width", args{0, "宽字符", ""}, "宽字符"},
+		{"PadRight wide charactors with space and smaller width", args{5, "宽字符", ""}, "宽字符"},
+		{"PadRight wide charactors with space and same width", args{6, "宽字符", ""}, "宽字符"},
 	}
 
 	for _, tt := range tests {
@@ -154,11 +154,11 @@ func TestPadRightX(t *testing.T) {
 		{"PadRightX with space and zero width", args{0, "test", " "}, "test"},
 		{"PadRightX with space and smaller width", args{3, "test", " "}, "test"},
 		{"PadRightX with space and same width", args{4, "test", " "}, "test"},
-		{"PadRightX wild charactors with space", args{10, "宽字符", " "}, "宽字符    "},
-		{"PadRightX wild charactors with space 2", args{10, "宽字符A", " "}, "宽字符A   "},
-		{"PadRightX wild charactors with space and zero width", args{0, "宽字符", " "}, "宽字符"},
-		{"PadRightX wild charactors with space and smaller width", args{5, "宽字符", " "}, "宽字符"},
-		{"PadRightX wild charactors with space and same width", args{6, "宽字符", " "}, "宽字符"},
+		{"PadRightX wide charactors with space", args{10, "宽字符", " "}, "宽字符    "},
+		{"PadRightX wide charactors with space 2", args{10, "宽字符A", " "}, "宽字符A   "},
+		{"PadRightX wide charactors with space and zero width", args{0, "宽字符", " "}, "宽字符"},
+		{"PadRightX wide charactors with space and smaller width", args{5, "宽字符", " "}, "宽字符"},
+		{"PadRightX wide charactors with space and same width", args{6, "宽字符", " "}, "宽字符"},
 	}
 
 	for _, tt := range tests {
@@ -189,11 +189,11 @@ func TestStringOr(t *testing.T) {
 		{"StringOr with zero width", args{"test", "b", []int{0}}, "test"},
 		{"StringOr with smaller width", args{"test", "b", []int{3}}, "test"},
 		{"StringOr with same width", args{"test", "b", []int{4}}, "test"},
-		{"StringOr wild charactors", args{"宽字符", "", []int{10}}, "宽字符    "},
-		{"StringOr wild charactors 2", args{"宽字符A", "", []int{10}}, "宽字符A   "},
-		{"StringOr wild charactors with zero width", args{"宽字符", "", []int{0}}, "宽字符"},
-		{"StringOr wild charactors with smaller width", args{"宽字符", "", []int{5}}, "宽字符"},
-		{"StringOr wild charactors with same width", args{"宽字符", "", []int{6}}, "宽字符"},
+		{"StringOr wide charactors", args{"宽字符", "", []int{10}}, "宽字符    "},
+		{"StringOr wide charactors 2", args{"宽字符A", "", []int{10}}, "宽字符A   "},
+		{"StringOr wide charactors with zero width", args{"宽字符", "", []int{0}}, "宽字符"},
+		{"StringOr wide charactors with smaller width", args{"宽字符", "", []int{5}}, "宽字符"},
+		{"StringOr wide charactors with same width", args{"宽字符", "", []int{6}}, "宽字符"},
 	}
 
 	for _, tt := range tests {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -304,6 +304,19 @@ func TestSplitString(t *testing.T) {
 				`test!`,
 			},
 		},
+		{
+			"SplitString mixed charactors and punctuation at eol",
+			args{
+				`测试的文本，用于验证CJK字符。`,
+				10,
+			},
+			[]string{
+				`测试的文`,
+				`本，用于验`,
+				`证CJK字`,
+				`符。`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -413,6 +426,17 @@ func TestSplitStringNL(t *testing.T) {
 				`world,` + "\r\n" +
 				`this is a` + "\r\n" +
 				`test!`,
+		},
+		{
+			"SplitString mixed charactors and punctuation at eol",
+			args{
+				`测试的文本，用于验证CJK字符。`,
+				10, nil,
+			},
+			`测试的文` + "\r\n" +
+				`本，用于验` + "\r\n" +
+				`证CJK字` + "\r\n" +
+				`符。`,
 		},
 	}
 

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -232,6 +232,31 @@ func TestSplitString(t *testing.T) {
 			},
 		},
 		{
+			"SplitString punctuation at eol",
+			args{
+				`Hello alex, this is a test.`,
+				10,
+			},
+			[]string{
+				`Hello`,
+				`alex, this`,
+				`is a test.`,
+			},
+		},
+		{
+			"SplitString punctuation at eol 2",
+			args{
+				`Hello alex, this is a test!!!`,
+				10,
+			},
+			[]string{
+				`Hello`,
+				`alex, this`,
+				`is a`,
+				`test!!!`,
+			},
+		},
+		{
 			"SplitString long text",
 			args{
 				`As your senses attune to the stillness around, you find yourself engulfed in an impenetrable void, ` +
@@ -312,6 +337,27 @@ func TestSplitStringNL(t *testing.T) {
 				`sentence` + "\r\n" +
 				`to be` + "\r\n" +
 				`tested.`,
+		},
+		{
+			"SplitStringNL punctuation at eol",
+			args{
+				`Hello alex, this is a test.`,
+				10, nil,
+			},
+			`Hello` + "\r\n" +
+				`alex, this` + "\r\n" +
+				`is a test.`,
+		},
+		{
+			"SplitStringNL punctuation at eol 2",
+			args{
+				`Hello alex, this is a test!!!`,
+				10, nil,
+			},
+			`Hello` + "\r\n" +
+				`alex, this` + "\r\n" +
+				`is a` + "\r\n" +
+				`test!!!`,
 		},
 		{
 			"SplitStringNL long text",

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
 )
 
 // Because turnCount, roundCount and timeTrackers are package-level globals,
@@ -206,52 +207,174 @@ func TestRand(t *testing.T) {
 }
 
 func TestSplitString(t *testing.T) {
-	// Basic test
-	input := "This is a sample sentence to be tested."
-	lines := SplitString(input, 10)
-
-	// We expect lines of around 10 characters wide
-	// For instance:
-	// "This is a" => length 10
-	// "sample" => length 6
-	// "sentence" => length 8
-	// "to be" => length 5
-	// "tested." => length 7
-	// This exact break-up can vary depending on spaces, etc.
-
-	if len(lines) < 3 {
-		t.Fatalf("Expected at least 3 lines, got %d", len(lines))
+	type args struct {
+		input string
+		width int
 	}
 
-	// Also test an input that includes explicit newlines
-	inputWithNewline := "This line fits\nand this line might not"
-	lines2 := SplitString(inputWithNewline, 10)
-	if len(lines2) < 2 {
-		t.Fatalf("Expected at least 2 lines because of explicit newline, got %d", len(lines2))
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			"SplitString",
+			args{
+				`This is a sample sentence to be tested.`,
+				10,
+			},
+			[]string{
+				`This is a`,
+				`sample`,
+				`sentence`,
+				`to be`,
+				`tested.`,
+			},
+		},
+		{
+			"SplitString long text",
+			args{
+				`As your senses attune to the stillness around, you find yourself engulfed in an impenetrable void, ` +
+					`a realm where darkness reigns supreme. ` +
+					`The abyss seems to stretch infinitely in all directions, ` +
+					`and you feel a chilling isolation seeping into your very bones.`,
+				79,
+			},
+			[]string{
+				`As your senses attune to the stillness around, you find yourself engulfed in an`,
+				`impenetrable void, a realm where darkness reigns supreme. The abyss seems to`,
+				`stretch infinitely in all directions, and you feel a chilling isolation seeping`,
+				`into your very bones.`,
+			},
+		},
+		{
+			"SplitString wide charactors",
+			args{
+				`当你的感官与周围的静谧相适应时，你发现自己被吞噬在一个无法穿透的虚空中，一个黑` +
+					`暗至上的领域。深渊似乎向四面八方无限延伸，你感到一种令人不寒而栗的孤独感正渗入` +
+					`你的骨髓。`,
+				79,
+			},
+			[]string{
+				`当你的感官与周围的静谧相适应时，你发现自己被吞噬在一个无法穿透的虚空中，一个黑`,
+				`暗至上的领域。深渊似乎向四面八方无限延伸，你感到一种令人不寒而栗的孤独感正渗入`,
+				`你的骨髓。`,
+			},
+		},
+		{
+			"SplitString mixed charactors",
+			args{
+				`这是一个测试文本，用于验证CJK字符和英文单词的分割行为。Hello world, this is a test!`,
+				10,
+			},
+			[]string{`这是一个测`,
+				`试文本，用`,
+				`于验证CJK`,
+				`字符和英文`,
+				`单词的分割`,
+				`行为。`,
+				`Hello`,
+				`world,`,
+				`this is a`,
+				`test!`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SplitString(tt.args.input, tt.args.width)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 
 func TestSplitStringNL(t *testing.T) {
-	input := "This is a longer line that we want to wrap around nicely."
-	wrapped := SplitStringNL(input, 10)
-
-	// We can simply check that the output does not exceed width 10 (excluding the optional prefix),
-	// and that it's separated by CRLF from the term package, though we won't check the CRLF specifically here.
-	lines := strings.Split(wrapped, "\r\n") // from term.CRLFStr
-	for _, line := range lines {
-		if len(line) > 10 {
-			t.Fatalf("Line %q exceeded the width of 10", line)
-		}
+	type args struct {
+		input  string
+		width  int
+		prefix []string
 	}
 
-	// Also check with prefix
-	prefixed := SplitStringNL(input, 10, "> ")
-	lines = strings.Split(prefixed, "\r\n")
-	// If there's more than one line, subsequent lines should have prefix
-	for i, line := range lines {
-		if i > 0 && !strings.HasPrefix(line, "> ") && line != "" {
-			t.Fatalf("Expected prefix '> ' on line %d, got %q", i, line)
-		}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"SplitStringNL",
+			args{
+				`This is a sample sentence to be tested.`,
+				10, nil,
+			},
+			`This is a` + "\r\n" +
+				`sample` + "\r\n" +
+				`sentence` + "\r\n" +
+				`to be` + "\r\n" +
+				`tested.`,
+		},
+		{
+			"SplitStringNL long text",
+			args{
+				`As your senses attune to the stillness around, you find yourself engulfed in an impenetrable void, ` +
+					`a realm where darkness reigns supreme. ` +
+					`The abyss seems to stretch infinitely in all directions, ` +
+					`and you feel a chilling isolation seeping into your very bones.`,
+				79, nil,
+			},
+			`As your senses attune to the stillness around, you find yourself engulfed in an` + "\r\n" +
+				`impenetrable void, a realm where darkness reigns supreme. The abyss seems to` + "\r\n" +
+				`stretch infinitely in all directions, and you feel a chilling isolation seeping` + "\r\n" +
+				`into your very bones.`,
+		},
+		{
+			"SplitStringNL with prefix",
+			args{
+				`As your senses attune to the stillness around, you find yourself engulfed in an impenetrable void, ` +
+					`a realm where darkness reigns supreme. ` +
+					`The abyss seems to stretch infinitely in all directions, ` +
+					`and you feel a chilling isolation seeping into your very bones.`,
+				79, []string{"> "},
+			},
+			`As your senses attune to the stillness around, you find yourself engulfed in an` + "\r\n" +
+				`> impenetrable void, a realm where darkness reigns supreme. The abyss seems to` + "\r\n" +
+				`> stretch infinitely in all directions, and you feel a chilling isolation seeping` + "\r\n" +
+				`> into your very bones.`,
+		},
+		{
+			"SplitStringNL wide charactors",
+			args{
+				`当你的感官与周围的静谧相适应时，你发现自己被吞噬在一个无法穿透的虚空中，一个黑` +
+					`暗至上的领域。深渊似乎向四面八方无限延伸，你感到一种令人不寒而栗的孤独感正渗入` +
+					`你的骨髓。`,
+				79, nil},
+			`当你的感官与周围的静谧相适应时，你发现自己被吞噬在一个无法穿透的虚空中，一个黑` + "\r\n" +
+				`暗至上的领域。深渊似乎向四面八方无限延伸，你感到一种令人不寒而栗的孤独感正渗入` + "\r\n" +
+				`你的骨髓。`,
+		},
+		{
+			"SplitStringNL mixed charactors",
+			args{
+				`这是一个测试文本，用于验证CJK字符和英文单词的分割行为。Hello world, this is a test!`,
+				10, nil},
+			`这是一个测` + "\r\n" +
+				`试文本，用` + "\r\n" +
+				`于验证CJK` + "\r\n" +
+				`字符和英文` + "\r\n" +
+				`单词的分割` + "\r\n" +
+				`行为。` + "\r\n" +
+				`Hello` + "\r\n" +
+				`world,` + "\r\n" +
+				`this is a` + "\r\n" +
+				`test!`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SplitStringNL(tt.args.input, tt.args.width, tt.args.prefix...)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 


### PR DESCRIPTION
Miscellaneous adjustments to accomodate string manipulation in languages other than english.

See: internal/templates/templatesfunctions_test.go