### PR TITLE
HTTP/HTTPS adjustments

### DIFF
--- a/_datafiles/config.yaml
+++ b/_datafiles/config.yaml
@@ -385,13 +385,16 @@ Network:
   # - LocalPort -
   #   A port that can only be accessed via localhost, but will not limit based on connection count
   LocalPort: 9999
-  # - WebPort -
+  # - HttpPort -
   #   The port the server listens on for web requests
-  WebPort: 80
+  HttpPort: 80
   # - HttpsPort -
   #   The port the server listens on for web requests
   #   Note: Must have a cert/key file (See FilePaths)
   HttpsPort: 443
+  # - HttpsRedirect -
+  #   If true, will send all http traffic to https with a redirect
+  HttpsRedirect: false
   # - AfkSeconds -
   #   If this many seconds pass without player input, they are flagged as afk
   #   Set to zero to never mark anyone as AFK

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -27,6 +27,10 @@ func (n *Network) Validate() {
 		n.WebPort = 0 // default
 	}
 
+	if n.HttpsPort < 0 {
+		n.HttpsPort = 0 // default
+	}
+
 	if n.AfkSeconds < 0 {
 		n.AfkSeconds = 0
 	}

--- a/internal/configs/config.network.go
+++ b/internal/configs/config.network.go
@@ -4,8 +4,9 @@ type Network struct {
 	MaxTelnetConnections ConfigInt         `yaml:"MaxTelnetConnections"` // Maximum number of telnet connections to accept
 	TelnetPort           ConfigSliceString `yaml:"TelnetPort"`           // One or more Ports used to accept telnet connections
 	LocalPort            ConfigInt         `yaml:"LocalPort"`            // Port used for admin connections, localhost only
-	WebPort              ConfigInt         `yaml:"WebPort"`              // Port used for web requests
+	HttpPort             ConfigInt         `yaml:"HttpPort"`             // Port used for web requests
 	HttpsPort            ConfigInt         `yaml:"HttpsPort"`            // Port used for web https requests
+	HttpsRedirect        ConfigBool        `yaml:"HttpsRedirect"`        // If true, http traffic will be redirected to https
 	AfkSeconds           ConfigInt         `yaml:"AfkSeconds"`           // How long until a player is marked as afk?
 	MaxIdleSeconds       ConfigInt         `yaml:"MaxIdleSeconds"`       // How many seconds a player can go without a command in game before being kicked.
 	TimeoutMods          ConfigBool        `yaml:"TimeoutMods"`          // Whether to kick admin/mods when idle too long.
@@ -23,8 +24,8 @@ func (n *Network) Validate() {
 		n.MaxTelnetConnections = 50 // default
 	}
 
-	if n.WebPort < 0 {
-		n.WebPort = 0 // default
+	if n.HttpPort < 0 {
+		n.HttpPort = 0 // default
 	}
 
 	if n.HttpsPort < 0 {

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -315,7 +315,7 @@ func Listen(wg *sync.WaitGroup, webSocketHandler func(*websocket.Conn)) {
 			Addr: fmt.Sprintf(`:%d`, networkConfig.HttpPort),
 		}
 
-		if networkConfig.HttpsRedirect {
+		if networkConfig.HttpsRedirect && networkConfig.HttpsPort != 0 {
 
 			var redirectHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 

--- a/main.go
+++ b/main.go
@@ -168,13 +168,19 @@ func main() {
 		"name", string(c.Server.MudName),
 	)
 
+	mudlog.Info(`========================`)
+
 	// Load all the data files up front.
 	loadAllDataFiles(false)
+
+	mudlog.Info(`========================`)
 
 	mudlog.Info("Mapper", "status", "precaching")
 	timeStart := time.Now()
 	mapper.PreCacheMaps()
 	mudlog.Info("Mapper", "status", "done", "time taken", time.Since(timeStart))
+
+	mudlog.Info(`========================`)
 
 	// Create the user index
 	idx := users.NewUserIndex()
@@ -195,7 +201,6 @@ func main() {
 
 	scripting.Setup(int(c.Scripting.LoadTimeoutMs), int(c.Scripting.RoomTimeoutMs))
 
-	//
 	mudlog.Info(`========================`)
 
 	// Trigger the load plugins event
@@ -219,6 +224,7 @@ func main() {
 	// Set the server to be alive
 	serverAlive.Store(true)
 
+	mudlog.Info(`========================`)
 	web.Listen(int(c.Network.WebPort), int(c.Network.HttpsPort), &wg, HandleWebSocketConnection)
 
 	allServerListeners := make([]net.Listener, 0, len(c.Network.TelnetPort))

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func main() {
 	serverAlive.Store(true)
 
 	mudlog.Info(`========================`)
-	web.Listen(int(c.Network.WebPort), int(c.Network.HttpsPort), &wg, HandleWebSocketConnection)
+	web.Listen(&wg, HandleWebSocketConnection)
 
 	allServerListeners := make([]net.Listener, 0, len(c.Network.TelnetPort))
 	for _, port := range c.Network.TelnetPort {

--- a/world.go
+++ b/world.go
@@ -1018,7 +1018,7 @@ func (w *World) UpdateStats() {
 		}
 	}
 
-	s.WebSocketPort = int(c.WebPort)
+	s.WebSocketPort = int(c.HttpPort)
 
 	web.UpdateStats(s)
 }


### PR DESCRIPTION
# Changes
* Validate private/public key pair before attempting to start server on HTTPS port.
* Improved logging of staging of web server start up/failure.
* Renaming `WebPort` to `HttpPort` in config.yaml
* Adding `HttpsRedirect` boolean. 
  * if true, will redirect http traffic to https. Must have both http and https running for this to work.
* Possible to run no web server at all by setting http/https ports to zero.

